### PR TITLE
chore: Dev Container のセットアップの hotfix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     fonts-noto-color-emoji
 
 # Install asdf
+SHELL ["/bin/bash", "-c"]
 RUN set -e -o pipefail && \
     curl -L 'https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz' -o /tmp/asdf.tar.gz && \
     tar -xz -C /usr/local/bin -f /tmp/asdf.tar.gz && \


### PR DESCRIPTION
- [x] [pipefail を実行するために bash をシェルとして指定](https://github.com/yantene/yantene.net/commit/c65e116d82e197043ba7577ac60689ada430e28c)

close #8
