### PR TITLE
chore: Dev Container のセットアップの hotfix 2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,23 @@ RUN apt-get update && \
 # Install asdf
 SHELL ["/bin/bash", "-c"]
 RUN set -e -o pipefail && \
-    curl -L 'https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz' -o /tmp/asdf.tar.gz && \
+    download_and_verify() { \
+        local url="$1" output="$2" expected_sha256="$3"; \
+        curl -L "$url" | tee "$output" | sha256sum -c <(echo "$expected_sha256  -"); \
+    } && \
+    download_and_verify \
+        'https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz' \
+        '/tmp/asdf.tar.gz' \
+        '4d3007070166cb0a652af26c3f0462b021e04cb26c4ab13894d13689da89f5b8' && \
     tar -xz -C /usr/local/bin -f /tmp/asdf.tar.gz && \
     rm /tmp/asdf.tar.gz && \
     mkdir -p /home/vscode/.config/fish/conf.d && \
-    curl -L 'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.fish' > /home/vscode/.config/fish/conf.d/asdf.fish && \
-    curl -L 'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.sh' > /etc/profile.d/asdf.sh && \
+    download_and_verify \
+        'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.sh' \
+        '/etc/profile.d/asdf.sh' \
+        'f3d785f3a0e2c0bb55a1f0eabe6ed8eb79ff0133bc062723368b971041b82fb3' && \
+    download_and_verify \
+        'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.fish' \
+        '/home/vscode/.config/fish/conf.d/asdf.fish' \
+        'c5e06629af2235a25971e2abb6d51fdf83b80ae766a493b2a6e3b1a70722dc9f' && \
     chown -R vscode:vscode /home/vscode/.config

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,4 +16,5 @@ RUN set -e -o pipefail && \
     rm /tmp/asdf.tar.gz && \
     mkdir -p /home/vscode/.config/fish/conf.d && \
     curl -L 'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.fish' > /home/vscode/.config/fish/conf.d/asdf.fish && \
+    curl -L 'https://raw.githubusercontent.com/asdf-vm/asdf/refs/tags/v0.18.0/asdf.sh' > /etc/profile.d/asdf.sh && \
     chown -R vscode:vscode /home/vscode/.config

--- a/.devcontainer/post_create.fish
+++ b/.devcontainer/post_create.fish
@@ -6,3 +6,5 @@ asdf install
 asdf reshim
 npm install -g pnpm
 asdf reshim
+
+pnpm config set store-dir ~/.pnpm-store --global


### PR DESCRIPTION
- [x] `.pnpm-store/` を作らせないために `store-dir` を global に指定
- [x] Claude Code や bash で asdf を実行できるようにした

close #8
