### PR TITLE
feat: #32 記事詳細 API とアセット配信 API の実装

### DIFF
--- a/.kiro/specs/note-detail-api/design.md
+++ b/.kiro/specs/note-detail-api/design.md
@@ -1,0 +1,548 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能は、フロントエンド開発者がスラッグを指定して記事のメタデータと Markdown 本文 (mdast 形式) を取得し、記事詳細ページをレンダリングするための 2 つの API エンドポイントを提供する。
+
+**Users**: フロントエンド開発者が記事詳細ページの構築と記事内画像の表示に利用する。
+
+**Impact**: 既存の `notesApp` Hono ルートグループに 2 つのエンドポイント (`GET /:noteSlug`、`GET /:noteSlug/assets/*`) を追加する。既存の一覧 API・再構築 API には影響を与えない。
+
+### Goals
+
+- スラッグ指定で記事のメタデータと mdast 形式の本文を単一 API で取得可能にする
+- mdast 内の相対画像パスをアセット配信 API の URL に自動解決する
+- 記事に紐づくアセットファイルをバイナリストリームで配信する
+- 既存のドメインモデル・インターフェースを活用し、コードベースの一貫性を維持する
+
+### Non-Goals
+
+- mdast から HTML への変換 (フロントエンド側の責務)
+- 画像のリサイズ・最適化処理
+- 記事のキャッシュ制御 (CDN キャッシュヘッダーの設計)
+- 認証・認可の追加
+
+## Architecture
+
+### Existing Architecture Analysis
+
+既存システムは以下のパターンに従っている。
+
+- **レイヤードアーキテクチャ**: Domain (エンティティ、VO、ユースケース、インターフェース) → Infra (D1/R2 実装) → Handlers (Hono ルート) → Workers (エントリポイント)
+- **CQRS**: リポジトリが Command/Query に分離されている
+- **ファクトリパターン**: `getApp(handler)` で React Router ハンドラをラップ
+- **RFC 9457 準拠エラー**: `ProblemDetails` 型による一貫したエラーレスポンス
+- **既存エンドポイント**: `GET /api/v1/notes` (一覧)、`POST /api/v1/notes/refresh` (再構築) が `notesApp` ルートグループに存在
+
+本機能はこれらのパターンを踏襲し、既存インターフェース (`INoteQueryRepository`、`IMarkdownStorage`、`IAssetStorage`) を活用して新しいエンドポイントを追加する。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    subgraph Workers
+        Entry[Cloudflare Workers Entry]
+    end
+
+    subgraph Handlers
+        NotesHandler[notesApp Hono Routes]
+    end
+
+    subgraph Domain
+        GetNoteDetailUC[GetNoteDetailUseCase]
+        MdastParser[markdownToMdast]
+        ImageResolver[resolveImageUrls]
+    end
+
+    subgraph DomainInterfaces
+        IQueryRepo[INoteQueryRepository]
+        IMdStorage[IMarkdownStorage]
+        IAssetStore[IAssetStorage]
+    end
+
+    subgraph Infra
+        D1Repo[NoteQueryRepository D1]
+        R2Md[MarkdownStorage R2]
+        R2Asset[AssetStorage R2]
+    end
+
+    Entry --> NotesHandler
+    NotesHandler -->|GET noteSlug| GetNoteDetailUC
+    NotesHandler -->|GET assets| IAssetStore
+    GetNoteDetailUC --> IQueryRepo
+    GetNoteDetailUC --> IMdStorage
+    GetNoteDetailUC --> MdastParser
+    MdastParser --> ImageResolver
+    IQueryRepo -.-> D1Repo
+    IMdStorage -.-> R2Md
+    IAssetStore -.-> R2Asset
+```
+
+**Architecture Integration**:
+
+- **Selected pattern**: 既存のレイヤードアーキテクチャ + UseCase パターンを踏襲
+- **Domain/feature boundaries**: mdast 変換ロジックはドメイン層に配置 (既存の `parseNoteContent` と同様)。ハンドラ層は HTTP 関心事のみ
+- **Existing patterns preserved**: CQRS、RFC 9457 エラーハンドリング、VO パターン、DIP
+- **New components rationale**: `GetNoteDetailUseCase` はメタデータ取得 + Markdown 取得 + mdast 変換の一連の処理をオーケストレーションするために必要。`markdownToMdast` と `resolveImageUrls` は独立した純粋関数として設計
+- **Steering compliance**: ドメイン層にインフラ固有名称なし、型安全、関数型プログラミング原則準拠
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+| --- | --- | --- | --- |
+| Backend / Services | Hono v4 | ルートハンドラ定義 | 既存 |
+| Backend / Domain | unified v11 + remark-parse v11 | Markdown to mdast 変換 | 既存依存 |
+| Backend / Domain | remark-frontmatter v5 | frontmatter 除去 | 既存依存 |
+| Backend / Domain | unist-util-visit v5 | mdast ツリー走査 | **新規追加** |
+| Backend / Domain | @types/mdast v4 | mdast 型定義 | **新規追加 (devDependency)** |
+| Data / Storage | Cloudflare D1 | 記事メタデータ取得 | 既存 |
+| Data / Storage | Cloudflare R2 | Markdown・アセット取得 | 既存 |
+
+## System Flows
+
+### 記事詳細取得フロー
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler as notesApp Handler
+    participant UC as GetNoteDetailUseCase
+    participant QR as INoteQueryRepository
+    participant MS as IMarkdownStorage
+    participant Parser as markdownToMdast
+
+    Client->>Handler: GET /api/v1/notes/{noteSlug}
+    Handler->>Handler: NoteSlug.create(noteSlug)
+    alt Invalid slug
+        Handler-->>Client: 400 ProblemDetails
+    end
+    Handler->>UC: execute(slug)
+    UC->>QR: findBySlug(slug)
+    alt Note not found in DB
+        UC-->>Handler: NoteNotFoundError
+        Handler-->>Client: 404 ProblemDetails
+    end
+    UC->>MS: get(slug)
+    alt Markdown not found
+        UC-->>Handler: MarkdownNotFoundError
+        Handler-->>Client: 404 ProblemDetails
+    end
+    UC->>UC: ReadableStream to string
+    UC->>Parser: markdownToMdast(content, slug)
+    Parser->>Parser: unified parse + frontmatter strip
+    Parser->>Parser: resolveImageUrls(tree, slug)
+    Parser-->>UC: mdast Root
+    UC-->>Handler: NoteDetail result
+    Handler-->>Client: 200 JSON response
+```
+
+### アセット配信フロー
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler as notesApp Handler
+    participant AS as IAssetStorage
+
+    Client->>Handler: GET /api/v1/notes/{noteSlug}/assets/{assetPath}
+    Handler->>Handler: NoteSlug.create(noteSlug)
+    alt Invalid slug
+        Handler-->>Client: 400 ProblemDetails
+    end
+    Handler->>Handler: ObjectKey.create(noteSlug/assetPath)
+    Handler->>AS: get(objectKey)
+    alt Asset not found
+        Handler-->>Client: 404 ProblemDetails
+    end
+    Handler-->>Client: 200 Binary stream with Content-Type and ETag
+```
+
+**Key Decisions**: アセット配信はユースケースを経由せず、ハンドラ層から `IAssetStorage` を直接呼び出す。単純なプロキシ動作でありドメインロジックが不要なため。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+| --- | --- | --- | --- | --- |
+| 1.1 | slug 指定でメタデータ + Markdown 取得 | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository.findBySlug, IMarkdownStorage.get | 記事詳細取得 |
+| 1.2 | メタデータフィールドの定義 | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
+| 1.3 | HTTP 200 レスポンス | notesApp Handler | -- | 記事詳細取得 |
+| 1.4 | Content-Type: application/json | notesApp Handler | -- | 記事詳細取得 |
+| 2.1 | frontmatter 除去 + mdast 変換 | markdownToMdast | unified + remark-parse + remark-frontmatter | 記事詳細取得 |
+| 2.2 | content フィールドに mdast を含める | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
+| 2.3 | unist/mdast 準拠パーサー使用 | markdownToMdast | unified, remark-parse | 記事詳細取得 |
+| 3.1 | 相対画像パスをアセット配信 URL に解決 | resolveImageUrls | -- | 記事詳細取得 |
+| 3.2 | 絶対 URL はそのまま保持 | resolveImageUrls | -- | 記事詳細取得 |
+| 3.3 | 全 image ノードを走査 | resolveImageUrls | unist-util-visit | 記事詳細取得 |
+| 4.1 | アセットバイナリデータ返却 | notesApp Handler | IAssetStorage.get | アセット配信 |
+| 4.2 | Content-Type にメディアタイプ設定 | notesApp Handler | AssetContent.contentType | アセット配信 |
+| 4.3 | HTTP 200 レスポンス | notesApp Handler | -- | アセット配信 |
+| 4.4 | ETag ヘッダー付与 | notesApp Handler | AssetContent.etag | アセット配信 |
+| 5.1 | DB に記事が存在しない場合 404 | GetNoteDetailUseCase, notesApp Handler | NoteNotFoundError | 記事詳細取得 |
+| 5.2 | Markdown ファイルが存在しない場合 404 | GetNoteDetailUseCase, notesApp Handler | MarkdownNotFoundError | 記事詳細取得 |
+| 5.3 | 不正な slug 形式の場合 400 | notesApp Handler | InvalidNoteSlugError | 記事詳細取得 |
+| 6.1 | アセットが存在しない場合 404 | notesApp Handler | -- | アセット配信 |
+| 6.2 | 不正な slug 形式の場合 400 | notesApp Handler | InvalidNoteSlugError | アセット配信 |
+| 7.1 | 内部エラー時 500 | notesApp Handler | ProblemDetails | 両フロー |
+| 7.2 | 内部エラーのログ出力 | notesApp Handler | console.error | 両フロー |
+| 7.3 | エラーの Content-Type: application/problem+json | notesApp Handler | -- | 両フロー |
+| 7.4 | アセット配信の内部エラー時 500 | notesApp Handler | ProblemDetails | アセット配信 |
+| 7.5 | アセット配信エラーの Content-Type | notesApp Handler | -- | アセット配信 |
+| 8.1 | レスポンス構造定義 | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
+| 8.2 | content に mdast Root ノード | markdownToMdast | Root (mdast) | 記事詳細取得 |
+| 8.3 | 日付フィールド ISO 8601 形式 | GetNoteDetailUseCase | -- | 記事詳細取得 |
+| 9.1 | notesApp に GET /:noteSlug 追加 | notesApp Handler | -- | 記事詳細取得 |
+| 9.2 | notesApp に GET /:noteSlug/assets/* 追加 | notesApp Handler | -- | アセット配信 |
+| 9.3 | 既存エンドポイントへの非影響 | notesApp Handler | -- | -- |
+| 9.4 | 既存インターフェースの活用 | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository, IMarkdownStorage, IAssetStorage | 両フロー |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+| --- | --- | --- | --- | --- | --- |
+| GetNoteDetailUseCase | Domain / UseCase | slug からメタデータ + mdast を取得 | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4 | INoteQueryRepository (P0), IMarkdownStorage (P0), markdownToMdast (P0) | Service |
+| markdownToMdast | Domain / Parser | Markdown を mdast に変換し画像パスを解決 | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2 | unified (P0), remark-parse (P0), unist-util-visit (P0) | Service |
+| resolveImageUrls | Domain / Parser | mdast 内の相対画像パスをアセット API URL に変換 | 3.1, 3.2, 3.3 | unist-util-visit (P0) | Service |
+| notesApp Handler (detail) | Handler | 記事詳細 API エンドポイント | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3 | GetNoteDetailUseCase (P0) | API |
+| notesApp Handler (asset) | Handler | アセット配信 API エンドポイント | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3 | IAssetStorage (P0) | API |
+| NoteDetailResponse | Shared / Types | 記事詳細 API レスポンス型定義 | 1.2, 8.1, 8.2, 8.3 | @types/mdast (P1) | -- |
+
+### Domain / UseCase
+
+#### GetNoteDetailUseCase
+
+| Field | Detail |
+| --- | --- |
+| Intent | slug を指定して記事のメタデータと mdast 形式の本文を取得する |
+| Requirements | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4 |
+
+**Responsibilities & Constraints**
+
+- `INoteQueryRepository` からメタデータを取得し、`IMarkdownStorage` から Markdown 本文を取得する
+- `ReadableStream` を文字列に変換し、`markdownToMdast` で mdast に変換する
+- 記事が DB に存在しない場合は `NoteNotFoundError` をスロー
+- Markdown がストレージに存在しない場合は `MarkdownNotFoundError` をスロー
+- ドメイン層に属し、HTTP やインフラの関心事を持たない
+
+**Dependencies**
+
+- Inbound: notesApp Handler -- 記事詳細リクエストの処理 (P0)
+- Outbound: INoteQueryRepository -- 記事メタデータ取得 (P0)
+- Outbound: IMarkdownStorage -- Markdown 本文取得 (P0)
+- Outbound: markdownToMdast -- mdast 変換 (P0)
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### Service Interface
+
+```typescript
+interface NoteDetailResult {
+  readonly id: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly imageUrl: string;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+  readonly content: Root;
+}
+
+class GetNoteDetailUseCase {
+  constructor(
+    private readonly queryRepository: INoteQueryRepository,
+    private readonly markdownStorage: IMarkdownStorage,
+  );
+
+  execute(slug: NoteSlug): Promise<NoteDetailResult>;
+}
+```
+
+- Preconditions: `slug` は有効な `NoteSlug` インスタンス
+- Postconditions: `NoteDetailResult` を返却、または `NoteNotFoundError` / `MarkdownNotFoundError` をスロー
+- Invariants: メタデータの日付フィールドは ISO 8601 形式 (`YYYY-MM-DD`) の文字列
+
+**Implementation Notes**
+
+- Integration: `ReadableStream` を `new Response(stream).text()` で文字列に変換
+- Validation: slug の検証はハンドラ層で `NoteSlug.create()` を呼び出す時点で行われる
+- Risks: 大きな Markdown ファイルでメモリ消費が増加するリスク (実用上は問題にならない規模)
+
+### Domain / Parser
+
+#### markdownToMdast
+
+| Field | Detail |
+| --- | --- |
+| Intent | Markdown 文字列を frontmatter 除去済みの mdast Root ノードに変換する |
+| Requirements | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2 |
+
+**Responsibilities & Constraints**
+
+- `unified` + `remark-parse` + `remark-frontmatter` で Markdown を mdast にパース
+- パース後のツリーから frontmatter (YAML ノード) を除外
+- `resolveImageUrls` を呼び出して相対画像パスを解決
+- 純粋関数として設計し、副作用を持たない
+
+**Dependencies**
+
+- Inbound: GetNoteDetailUseCase -- mdast 変換の呼び出し (P0)
+- External: unified v11 -- パイプラインフレームワーク (P0)
+- External: remark-parse v11 -- Markdown パーサー (P0)
+- External: remark-frontmatter v5 -- frontmatter 処理 (P0)
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### Service Interface
+
+```typescript
+function markdownToMdast(content: string, slug: NoteSlug): Root;
+```
+
+- Preconditions: `content` は有効な Markdown 文字列
+- Postconditions: frontmatter が除去され、相対画像パスが解決された mdast `Root` ノードを返却
+- Invariants: 返却される `Root` ノードに type `"yaml"` の子ノードは含まれない
+
+#### resolveImageUrls
+
+| Field | Detail |
+| --- | --- |
+| Intent | mdast ツリー内の相対画像パスをアセット配信 API の URL に変換する |
+| Requirements | 3.1, 3.2, 3.3 |
+
+**Responsibilities & Constraints**
+
+- `unist-util-visit` で mdast ツリー全体を走査し、`image` ノードを検出
+- 相対パス (`http://` / `https://` で始まらない URL) をアセット配信 API パス (`/api/v1/notes/{slug}/assets/{path}`) に変換
+- 絶対 URL はそのまま保持
+- 純粋関数として設計 (新しいツリーを返却、元のツリーを変更しない)
+
+**Dependencies**
+
+- Inbound: markdownToMdast -- 画像パス解決の呼び出し (P0)
+- External: unist-util-visit v5 -- ツリー走査 (P0)
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### Service Interface
+
+```typescript
+function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
+```
+
+- Preconditions: `tree` は有効な mdast `Root` ノード
+- Postconditions: 全 image ノードの相対 URL がアセット配信 API パスに変換された新しい `Root` ノードを返却
+- Invariants: 絶対 URL (`http://`, `https://`) は変更されない
+
+### Handler
+
+#### notesApp Handler (detail)
+
+| Field | Detail |
+| --- | --- |
+| Intent | GET /api/v1/notes/:noteSlug エンドポイントのリクエスト処理 |
+| Requirements | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3 |
+
+**Responsibilities & Constraints**
+
+- パスパラメータ `noteSlug` を `NoteSlug.create()` で検証
+- `GetNoteDetailUseCase` を呼び出して結果を JSON レスポンスとして返却
+- ドメイン例外を RFC 9457 ProblemDetails に変換
+- 既存の `/` (一覧) と `/refresh` (再構築) エンドポイントに影響しない配置
+
+**Dependencies**
+
+- Inbound: Cloudflare Workers -- HTTP リクエスト (P0)
+- Outbound: GetNoteDetailUseCase -- 記事詳細取得 (P0)
+- Outbound: NoteQueryRepository (D1) -- DI 構築 (P0)
+- Outbound: MarkdownStorage (R2) -- DI 構築 (P0)
+
+**Contracts**: Service [ ] / API [x] / Event [ ] / Batch [ ] / State [ ]
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+| --- | --- | --- | --- | --- |
+| GET | /api/v1/notes/:noteSlug | Path: noteSlug (string) | NoteDetailResponse (200) | 400, 404, 500 |
+
+**Implementation Notes**
+
+- Integration: 既存の `notesApp` チェインに `.get("/:noteSlug", handler)` を追加。ルート定義順序に注意 (一覧 `/` と再構築 `/refresh` の後に配置)
+- Validation: `NoteSlug.create()` が `InvalidNoteSlugError` をスローした場合に 400 を返却
+- Risks: `/:noteSlug` が `/refresh` と競合しないよう、ルート定義順序を既存エンドポイントの後にする
+
+#### notesApp Handler (asset)
+
+| Field | Detail |
+| --- | --- |
+| Intent | GET /api/v1/notes/:noteSlug/assets/* エンドポイントのリクエスト処理 |
+| Requirements | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3 |
+
+**Responsibilities & Constraints**
+
+- パスパラメータ `noteSlug` を `NoteSlug.create()` で検証
+- ワイルドカードパラメータからアセットパスを取得
+- `noteSlug/assetPath` を連結して `ObjectKey.create()` で R2 キーを構築
+- `IAssetStorage.get()` でアセットを取得し、バイナリストリームとして返却
+- Content-Type と ETag をレスポンスヘッダーに設定
+
+**Dependencies**
+
+- Inbound: Cloudflare Workers -- HTTP リクエスト (P0)
+- Outbound: AssetStorage (R2) -- アセット取得 (P0)
+
+**Contracts**: Service [ ] / API [x] / Event [ ] / Batch [ ] / State [ ]
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+| --- | --- | --- | --- | --- |
+| GET | /api/v1/notes/:noteSlug/assets/* | Path: noteSlug (string), assetPath (string) | Binary stream (200) | 400, 404, 500 |
+
+**Implementation Notes**
+
+- Integration: 既存の `notesApp` チェインに `.get("/:noteSlug/assets/*", handler)` を追加
+- Validation: `NoteSlug.create()` で slug 検証。assetPath が空の場合の処理を考慮
+- Risks: Hono のワイルドカードパラメータでスラッシュを含むパスが取得できることを検証する必要がある
+
+### Shared / Types
+
+#### NoteDetailResponse
+
+| Field | Detail |
+| --- | --- |
+| Intent | 記事詳細 API のレスポンス型を定義する |
+| Requirements | 1.2, 8.1, 8.2, 8.3 |
+
+**Implementation Notes**
+
+- `app/lib/types/notes.ts` に追加
+- `Root` 型は `mdast` パッケージからインポート
+
+### Domain / Errors
+
+#### MarkdownNotFoundError (新規)
+
+| Field | Detail |
+| --- | --- |
+| Intent | 指定された slug の Markdown ファイルがストレージに存在しない場合のエラー |
+| Requirements | 5.2 |
+
+**Implementation Notes**
+
+- 既存の `app/backend/domain/note/errors.ts` に追加
+- 既存の `NoteNotFoundError` は DB レベルの不存在を示すため、ストレージ不存在用に分離
+
+#### NoteNotFoundError (新規)
+
+| Field | Detail |
+| --- | --- |
+| Intent | 指定された slug の記事が DB に存在しない場合のエラー |
+| Requirements | 5.1 |
+
+**Implementation Notes**
+
+- 既存の `app/backend/domain/note/errors.ts` に追加
+- `findBySlug` が `undefined` を返した場合に `GetNoteDetailUseCase` がスローする
+
+## Data Models
+
+### Domain Model
+
+本機能は新しいエンティティや VO を追加しない。既存の以下のモデルを活用する。
+
+- **Note エンティティ**: `id`, `title`, `slug`, `etag`, `imageUrl`, `publishedOn`, `lastModifiedOn`
+- **NoteSlug VO**: slug バリデーションと生成
+- **ObjectKey VO**: R2 オブジェクトキーの表現
+- **ETag VO**: ETag の表現
+- **ContentType VO**: メディアタイプの表現
+
+### Data Contracts & Integration
+
+#### 記事詳細 API レスポンス
+
+```typescript
+import type { Root } from "mdast";
+
+type NoteDetailResponse = {
+  readonly id: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly imageUrl: string;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+  readonly content: Root;
+};
+```
+
+レスポンス例:
+
+```json
+{
+  "id": "abc-123",
+  "title": "My Article",
+  "slug": "my-article",
+  "imageUrl": "https://example.com/cover.png",
+  "publishedOn": "2026-02-15",
+  "lastModifiedOn": "2026-02-18",
+  "content": {
+    "type": "root",
+    "children": [
+      {
+        "type": "heading",
+        "depth": 1,
+        "children": [{ "type": "text", "value": "Introduction" }]
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "image",
+            "url": "/api/v1/notes/my-article/assets/images/diagram.png",
+            "alt": "Diagram"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### アセット配信 API レスポンス
+
+- **Body**: バイナリストリーム (ReadableStream)
+- **Headers**:
+  - `Content-Type`: アセットの実際のメディアタイプ (例: `image/png`)
+  - `ETag`: アセットの ETag 値
+
+## Error Handling
+
+### Error Strategy
+
+既存の RFC 9457 ProblemDetails パターンに従い、ドメイン例外をハンドラ層で HTTP レスポンスに変換する。
+
+### Error Categories and Responses
+
+| Error | HTTP Status | ProblemDetails title | Trigger |
+| --- | --- | --- | --- |
+| `InvalidNoteSlugError` | 400 | Bad Request | slug 形式が不正 |
+| `NoteNotFoundError` | 404 | Not Found | DB に記事が存在しない |
+| `MarkdownNotFoundError` | 404 | Not Found | R2 に Markdown が存在しない |
+| Asset not found | 404 | Not Found | R2 にアセットが存在しない |
+| その他の Error | 500 | Internal Server Error | DB/R2 アクセスエラー等 |
+
+### Monitoring
+
+- 500 エラー発生時に `console.error` でエラー詳細をログ出力 (既存パターン踏襲)
+- Cloudflare Workers の Observability 機能 (`observability.enabled: true`) でメトリクス収集
+
+## Testing Strategy
+
+### Unit Tests
+
+- `markdownToMdast`: frontmatter 除去、mdast Root ノード生成、空の Markdown 処理
+- `resolveImageUrls`: 相対パスの解決、絶対 URL の保持、image ノードがない場合のパススルー、ネストされた image ノードの走査
+- `GetNoteDetailUseCase`: 正常系レスポンス構造の検証、NoteNotFoundError/MarkdownNotFoundError のスロー
+
+### Integration Tests
+
+- `GET /api/v1/notes/:noteSlug`: 正常レスポンス構造、404 (記事なし)、400 (不正 slug)、500 (内部エラー)
+- `GET /api/v1/notes/:noteSlug/assets/*`: バイナリストリーム返却、Content-Type 設定、ETag ヘッダー、404 (アセットなし)
+- 既存エンドポイントへの非影響: `GET /api/v1/notes` と `POST /api/v1/notes/refresh` が引き続き正常動作

--- a/.kiro/specs/note-detail-api/design.md
+++ b/.kiro/specs/note-detail-api/design.md
@@ -88,15 +88,15 @@ graph TB
 
 ### Technology Stack
 
-| Layer | Choice / Version | Role in Feature | Notes |
-| --- | --- | --- | --- |
-| Backend / Services | Hono v4 | ルートハンドラ定義 | 既存 |
-| Backend / Domain | unified v11 + remark-parse v11 | Markdown to mdast 変換 | 既存依存 |
-| Backend / Domain | remark-frontmatter v5 | frontmatter 除去 | 既存依存 |
-| Backend / Domain | unist-util-visit v5 | mdast ツリー走査 | **新規追加** |
-| Backend / Domain | @types/mdast v4 | mdast 型定義 | **新規追加 (devDependency)** |
-| Data / Storage | Cloudflare D1 | 記事メタデータ取得 | 既存 |
-| Data / Storage | Cloudflare R2 | Markdown・アセット取得 | 既存 |
+| Layer              | Choice / Version               | Role in Feature        | Notes                        |
+| ------------------ | ------------------------------ | ---------------------- | ---------------------------- |
+| Backend / Services | Hono v4                        | ルートハンドラ定義     | 既存                         |
+| Backend / Domain   | unified v11 + remark-parse v11 | Markdown to mdast 変換 | 既存依存                     |
+| Backend / Domain   | remark-frontmatter v5          | frontmatter 除去       | 既存依存                     |
+| Backend / Domain   | unist-util-visit v5            | mdast ツリー走査       | **新規追加**                 |
+| Backend / Domain   | @types/mdast v4                | mdast 型定義           | **新規追加 (devDependency)** |
+| Data / Storage     | Cloudflare D1                  | 記事メタデータ取得     | 既存                         |
+| Data / Storage     | Cloudflare R2                  | Markdown・アセット取得 | 既存                         |
 
 ## System Flows
 
@@ -161,59 +161,59 @@ sequenceDiagram
 
 ## Requirements Traceability
 
-| Requirement | Summary | Components | Interfaces | Flows |
-| --- | --- | --- | --- | --- |
-| 1.1 | slug 指定でメタデータ + Markdown 取得 | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository.findBySlug, IMarkdownStorage.get | 記事詳細取得 |
-| 1.2 | メタデータフィールドの定義 | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
-| 1.3 | HTTP 200 レスポンス | notesApp Handler | -- | 記事詳細取得 |
-| 1.4 | Content-Type: application/json | notesApp Handler | -- | 記事詳細取得 |
-| 2.1 | frontmatter 除去 + mdast 変換 | markdownToMdast | unified + remark-parse + remark-frontmatter | 記事詳細取得 |
-| 2.2 | content フィールドに mdast を含める | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
-| 2.3 | unist/mdast 準拠パーサー使用 | markdownToMdast | unified, remark-parse | 記事詳細取得 |
-| 3.1 | 相対画像パスをアセット配信 URL に解決 | resolveImageUrls | -- | 記事詳細取得 |
-| 3.2 | 絶対 URL はそのまま保持 | resolveImageUrls | -- | 記事詳細取得 |
-| 3.3 | 全 image ノードを走査 | resolveImageUrls | unist-util-visit | 記事詳細取得 |
-| 4.1 | アセットバイナリデータ返却 | notesApp Handler | IAssetStorage.get | アセット配信 |
-| 4.2 | Content-Type にメディアタイプ設定 | notesApp Handler | AssetContent.contentType | アセット配信 |
-| 4.3 | HTTP 200 レスポンス | notesApp Handler | -- | アセット配信 |
-| 4.4 | ETag ヘッダー付与 | notesApp Handler | AssetContent.etag | アセット配信 |
-| 5.1 | DB に記事が存在しない場合 404 | GetNoteDetailUseCase, notesApp Handler | NoteNotFoundError | 記事詳細取得 |
-| 5.2 | Markdown ファイルが存在しない場合 404 | GetNoteDetailUseCase, notesApp Handler | MarkdownNotFoundError | 記事詳細取得 |
-| 5.3 | 不正な slug 形式の場合 400 | notesApp Handler | InvalidNoteSlugError | 記事詳細取得 |
-| 6.1 | アセットが存在しない場合 404 | notesApp Handler | -- | アセット配信 |
-| 6.2 | 不正な slug 形式の場合 400 | notesApp Handler | InvalidNoteSlugError | アセット配信 |
-| 7.1 | 内部エラー時 500 | notesApp Handler | ProblemDetails | 両フロー |
-| 7.2 | 内部エラーのログ出力 | notesApp Handler | console.error | 両フロー |
-| 7.3 | エラーの Content-Type: application/problem+json | notesApp Handler | -- | 両フロー |
-| 7.4 | アセット配信の内部エラー時 500 | notesApp Handler | ProblemDetails | アセット配信 |
-| 7.5 | アセット配信エラーの Content-Type | notesApp Handler | -- | アセット配信 |
-| 8.1 | レスポンス構造定義 | GetNoteDetailUseCase | NoteDetailResponse 型 | 記事詳細取得 |
-| 8.2 | content に mdast Root ノード | markdownToMdast | Root (mdast) | 記事詳細取得 |
-| 8.3 | 日付フィールド ISO 8601 形式 | GetNoteDetailUseCase | -- | 記事詳細取得 |
-| 9.1 | notesApp に GET /:noteSlug 追加 | notesApp Handler | -- | 記事詳細取得 |
-| 9.2 | notesApp に GET /:noteSlug/assets/* 追加 | notesApp Handler | -- | アセット配信 |
-| 9.3 | 既存エンドポイントへの非影響 | notesApp Handler | -- | -- |
-| 9.4 | 既存インターフェースの活用 | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository, IMarkdownStorage, IAssetStorage | 両フロー |
+| Requirement | Summary                                         | Components                             | Interfaces                                            | Flows        |
+| ----------- | ----------------------------------------------- | -------------------------------------- | ----------------------------------------------------- | ------------ |
+| 1.1         | slug 指定でメタデータ + Markdown 取得           | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository.findBySlug, IMarkdownStorage.get | 記事詳細取得 |
+| 1.2         | メタデータフィールドの定義                      | GetNoteDetailUseCase                   | NoteDetailResponse 型                                 | 記事詳細取得 |
+| 1.3         | HTTP 200 レスポンス                             | notesApp Handler                       | --                                                    | 記事詳細取得 |
+| 1.4         | Content-Type: application/json                  | notesApp Handler                       | --                                                    | 記事詳細取得 |
+| 2.1         | frontmatter 除去 + mdast 変換                   | markdownToMdast                        | unified + remark-parse + remark-frontmatter           | 記事詳細取得 |
+| 2.2         | content フィールドに mdast を含める             | GetNoteDetailUseCase                   | NoteDetailResponse 型                                 | 記事詳細取得 |
+| 2.3         | unist/mdast 準拠パーサー使用                    | markdownToMdast                        | unified, remark-parse                                 | 記事詳細取得 |
+| 3.1         | 相対画像パスをアセット配信 URL に解決           | resolveImageUrls                       | --                                                    | 記事詳細取得 |
+| 3.2         | 絶対 URL はそのまま保持                         | resolveImageUrls                       | --                                                    | 記事詳細取得 |
+| 3.3         | 全 image ノードを走査                           | resolveImageUrls                       | unist-util-visit                                      | 記事詳細取得 |
+| 4.1         | アセットバイナリデータ返却                      | notesApp Handler                       | IAssetStorage.get                                     | アセット配信 |
+| 4.2         | Content-Type にメディアタイプ設定               | notesApp Handler                       | AssetContent.contentType                              | アセット配信 |
+| 4.3         | HTTP 200 レスポンス                             | notesApp Handler                       | --                                                    | アセット配信 |
+| 4.4         | ETag ヘッダー付与                               | notesApp Handler                       | AssetContent.etag                                     | アセット配信 |
+| 5.1         | DB に記事が存在しない場合 404                   | GetNoteDetailUseCase, notesApp Handler | NoteNotFoundError                                     | 記事詳細取得 |
+| 5.2         | Markdown ファイルが存在しない場合 404           | GetNoteDetailUseCase, notesApp Handler | MarkdownNotFoundError                                 | 記事詳細取得 |
+| 5.3         | 不正な slug 形式の場合 400                      | notesApp Handler                       | InvalidNoteSlugError                                  | 記事詳細取得 |
+| 6.1         | アセットが存在しない場合 404                    | notesApp Handler                       | --                                                    | アセット配信 |
+| 6.2         | 不正な slug 形式の場合 400                      | notesApp Handler                       | InvalidNoteSlugError                                  | アセット配信 |
+| 7.1         | 内部エラー時 500                                | notesApp Handler                       | ProblemDetails                                        | 両フロー     |
+| 7.2         | 内部エラーのログ出力                            | notesApp Handler                       | console.error                                         | 両フロー     |
+| 7.3         | エラーの Content-Type: application/problem+json | notesApp Handler                       | --                                                    | 両フロー     |
+| 7.4         | アセット配信の内部エラー時 500                  | notesApp Handler                       | ProblemDetails                                        | アセット配信 |
+| 7.5         | アセット配信エラーの Content-Type               | notesApp Handler                       | --                                                    | アセット配信 |
+| 8.1         | レスポンス構造定義                              | GetNoteDetailUseCase                   | NoteDetailResponse 型                                 | 記事詳細取得 |
+| 8.2         | content に mdast Root ノード                    | markdownToMdast                        | Root (mdast)                                          | 記事詳細取得 |
+| 8.3         | 日付フィールド ISO 8601 形式                    | GetNoteDetailUseCase                   | --                                                    | 記事詳細取得 |
+| 9.1         | notesApp に GET /:noteSlug 追加                 | notesApp Handler                       | --                                                    | 記事詳細取得 |
+| 9.2         | notesApp に GET /:noteSlug/assets/\* 追加       | notesApp Handler                       | --                                                    | アセット配信 |
+| 9.3         | 既存エンドポイントへの非影響                    | notesApp Handler                       | --                                                    | --           |
+| 9.4         | 既存インターフェースの活用                      | GetNoteDetailUseCase, notesApp Handler | INoteQueryRepository, IMarkdownStorage, IAssetStorage | 両フロー     |
 
 ## Components and Interfaces
 
-| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
-| --- | --- | --- | --- | --- | --- |
-| GetNoteDetailUseCase | Domain / UseCase | slug からメタデータ + mdast を取得 | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4 | INoteQueryRepository (P0), IMarkdownStorage (P0), markdownToMdast (P0) | Service |
-| markdownToMdast | Domain / Parser | Markdown を mdast に変換し画像パスを解決 | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2 | unified (P0), remark-parse (P0), unist-util-visit (P0) | Service |
-| resolveImageUrls | Domain / Parser | mdast 内の相対画像パスをアセット API URL に変換 | 3.1, 3.2, 3.3 | unist-util-visit (P0) | Service |
-| notesApp Handler (detail) | Handler | 記事詳細 API エンドポイント | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3 | GetNoteDetailUseCase (P0) | API |
-| notesApp Handler (asset) | Handler | アセット配信 API エンドポイント | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3 | IAssetStorage (P0) | API |
-| NoteDetailResponse | Shared / Types | 記事詳細 API レスポンス型定義 | 1.2, 8.1, 8.2, 8.3 | @types/mdast (P1) | -- |
+| Component                 | Domain/Layer     | Intent                                          | Req Coverage                                          | Key Dependencies (P0/P1)                                               | Contracts |
+| ------------------------- | ---------------- | ----------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- | --------- |
+| GetNoteDetailUseCase      | Domain / UseCase | slug からメタデータ + mdast を取得              | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4           | INoteQueryRepository (P0), IMarkdownStorage (P0), markdownToMdast (P0) | Service   |
+| markdownToMdast           | Domain / Parser  | Markdown を mdast に変換し画像パスを解決        | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2                     | unified (P0), remark-parse (P0), unist-util-visit (P0)                 | Service   |
+| resolveImageUrls          | Domain / Parser  | mdast 内の相対画像パスをアセット API URL に変換 | 3.1, 3.2, 3.3                                         | unist-util-visit (P0)                                                  | Service   |
+| notesApp Handler (detail) | Handler          | 記事詳細 API エンドポイント                     | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3 | GetNoteDetailUseCase (P0)                                              | API       |
+| notesApp Handler (asset)  | Handler          | アセット配信 API エンドポイント                 | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3      | IAssetStorage (P0)                                                     | API       |
+| NoteDetailResponse        | Shared / Types   | 記事詳細 API レスポンス型定義                   | 1.2, 8.1, 8.2, 8.3                                    | @types/mdast (P1)                                                      | --        |
 
 ### Domain / UseCase
 
 #### GetNoteDetailUseCase
 
-| Field | Detail |
-| --- | --- |
-| Intent | slug を指定して記事のメタデータと mdast 形式の本文を取得する |
-| Requirements | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4 |
+| Field        | Detail                                                       |
+| ------------ | ------------------------------------------------------------ |
+| Intent       | slug を指定して記事のメタデータと mdast 形式の本文を取得する |
+| Requirements | 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4                  |
 
 **Responsibilities & Constraints**
 
@@ -269,10 +269,10 @@ class GetNoteDetailUseCase {
 
 #### markdownToMdast
 
-| Field | Detail |
-| --- | --- |
-| Intent | Markdown 文字列を frontmatter 除去済みの mdast Root ノードに変換する |
-| Requirements | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2 |
+| Field        | Detail                                                               |
+| ------------ | -------------------------------------------------------------------- |
+| Intent       | Markdown 文字列を frontmatter 除去済みの mdast Root ノードに変換する |
+| Requirements | 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 8.2                                    |
 
 **Responsibilities & Constraints**
 
@@ -302,10 +302,10 @@ function markdownToMdast(content: string, slug: NoteSlug): Root;
 
 #### resolveImageUrls
 
-| Field | Detail |
-| --- | --- |
-| Intent | mdast ツリー内の相対画像パスをアセット配信 API の URL に変換する |
-| Requirements | 3.1, 3.2, 3.3 |
+| Field        | Detail                                                           |
+| ------------ | ---------------------------------------------------------------- |
+| Intent       | mdast ツリー内の相対画像パスをアセット配信 API の URL に変換する |
+| Requirements | 3.1, 3.2, 3.3                                                    |
 
 **Responsibilities & Constraints**
 
@@ -335,10 +335,10 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 #### notesApp Handler (detail)
 
-| Field | Detail |
-| --- | --- |
-| Intent | GET /api/v1/notes/:noteSlug エンドポイントのリクエスト処理 |
-| Requirements | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3 |
+| Field        | Detail                                                     |
+| ------------ | ---------------------------------------------------------- |
+| Intent       | GET /api/v1/notes/:noteSlug エンドポイントのリクエスト処理 |
+| Requirements | 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3      |
 
 **Responsibilities & Constraints**
 
@@ -358,9 +358,9 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 ##### API Contract
 
-| Method | Endpoint | Request | Response | Errors |
-| --- | --- | --- | --- | --- |
-| GET | /api/v1/notes/:noteSlug | Path: noteSlug (string) | NoteDetailResponse (200) | 400, 404, 500 |
+| Method | Endpoint                | Request                 | Response                 | Errors        |
+| ------ | ----------------------- | ----------------------- | ------------------------ | ------------- |
+| GET    | /api/v1/notes/:noteSlug | Path: noteSlug (string) | NoteDetailResponse (200) | 400, 404, 500 |
 
 **Implementation Notes**
 
@@ -370,10 +370,10 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 #### notesApp Handler (asset)
 
-| Field | Detail |
-| --- | --- |
-| Intent | GET /api/v1/notes/:noteSlug/assets/* エンドポイントのリクエスト処理 |
-| Requirements | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3 |
+| Field        | Detail                                                               |
+| ------------ | -------------------------------------------------------------------- |
+| Intent       | GET /api/v1/notes/:noteSlug/assets/\* エンドポイントのリクエスト処理 |
+| Requirements | 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3                     |
 
 **Responsibilities & Constraints**
 
@@ -392,9 +392,9 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 ##### API Contract
 
-| Method | Endpoint | Request | Response | Errors |
-| --- | --- | --- | --- | --- |
-| GET | /api/v1/notes/:noteSlug/assets/* | Path: noteSlug (string), assetPath (string) | Binary stream (200) | 400, 404, 500 |
+| Method | Endpoint                          | Request                                     | Response            | Errors        |
+| ------ | --------------------------------- | ------------------------------------------- | ------------------- | ------------- |
+| GET    | /api/v1/notes/:noteSlug/assets/\* | Path: noteSlug (string), assetPath (string) | Binary stream (200) | 400, 404, 500 |
 
 **Implementation Notes**
 
@@ -406,10 +406,10 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 #### NoteDetailResponse
 
-| Field | Detail |
-| --- | --- |
-| Intent | 記事詳細 API のレスポンス型を定義する |
-| Requirements | 1.2, 8.1, 8.2, 8.3 |
+| Field        | Detail                                |
+| ------------ | ------------------------------------- |
+| Intent       | 記事詳細 API のレスポンス型を定義する |
+| Requirements | 1.2, 8.1, 8.2, 8.3                    |
 
 **Implementation Notes**
 
@@ -420,10 +420,10 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 #### MarkdownNotFoundError (新規)
 
-| Field | Detail |
-| --- | --- |
-| Intent | 指定された slug の Markdown ファイルがストレージに存在しない場合のエラー |
-| Requirements | 5.2 |
+| Field        | Detail                                                                   |
+| ------------ | ------------------------------------------------------------------------ |
+| Intent       | 指定された slug の Markdown ファイルがストレージに存在しない場合のエラー |
+| Requirements | 5.2                                                                      |
 
 **Implementation Notes**
 
@@ -432,10 +432,10 @@ function resolveImageUrls(tree: Root, slug: NoteSlug): Root;
 
 #### NoteNotFoundError (新規)
 
-| Field | Detail |
-| --- | --- |
-| Intent | 指定された slug の記事が DB に存在しない場合のエラー |
-| Requirements | 5.1 |
+| Field        | Detail                                               |
+| ------------ | ---------------------------------------------------- |
+| Intent       | 指定された slug の記事が DB に存在しない場合のエラー |
+| Requirements | 5.1                                                  |
 
 **Implementation Notes**
 
@@ -520,13 +520,13 @@ type NoteDetailResponse = {
 
 ### Error Categories and Responses
 
-| Error | HTTP Status | ProblemDetails title | Trigger |
-| --- | --- | --- | --- |
-| `InvalidNoteSlugError` | 400 | Bad Request | slug 形式が不正 |
-| `NoteNotFoundError` | 404 | Not Found | DB に記事が存在しない |
-| `MarkdownNotFoundError` | 404 | Not Found | R2 に Markdown が存在しない |
-| Asset not found | 404 | Not Found | R2 にアセットが存在しない |
-| その他の Error | 500 | Internal Server Error | DB/R2 アクセスエラー等 |
+| Error                   | HTTP Status | ProblemDetails title  | Trigger                     |
+| ----------------------- | ----------- | --------------------- | --------------------------- |
+| `InvalidNoteSlugError`  | 400         | Bad Request           | slug 形式が不正             |
+| `NoteNotFoundError`     | 404         | Not Found             | DB に記事が存在しない       |
+| `MarkdownNotFoundError` | 404         | Not Found             | R2 に Markdown が存在しない |
+| Asset not found         | 404         | Not Found             | R2 にアセットが存在しない   |
+| その他の Error          | 500         | Internal Server Error | DB/R2 アクセスエラー等      |
 
 ### Monitoring
 

--- a/.kiro/specs/note-detail-api/requirements.md
+++ b/.kiro/specs/note-detail-api/requirements.md
@@ -1,9 +1,105 @@
 # Requirements Document
 
-## Project Description (Input)
+## Introduction
 
-記事詳細 API (`GET /api/v1/notes/{noteSlug}`) の実装。記事メタデータに加え、Markdown 本文を mdast（Markdown Abstract Syntax Tree）形式で返す。mdast 内の相対画像パスはアセット配信 API (`GET /api/v1/notes/{noteSlug}/assets/{assetPath}`) の URL に解決する。
+記事詳細 API の要件定義書。2つの API エンドポイントを定義する。
+1. **記事詳細 API** (`GET /api/v1/notes/{noteSlug}`) -- 記事のメタデータに加え、Markdown 本文を mdast (Markdown Abstract Syntax Tree) 形式で返す。mdast 内の相対画像パスはアセット配信 API の URL に解決する。
+2. **アセット配信 API** (`GET /api/v1/notes/{noteSlug}/assets/{assetPath}`) -- 記事に紐づく画像等のアセットファイルをバイナリストリームとして配信する。
+
+既存の Note ドメインモデル、`INoteQueryRepository`、`IMarkdownStorage`、`IAssetStorage` インターフェース、および `notesApp` Hono ルートグループ上にエンドポイントを追加する。
 
 ## Requirements
 
-<!-- Will be generated in /kiro:spec-requirements phase -->
+### Requirement 1: 記事詳細の取得
+
+**Objective:** As a フロントエンド開発者, I want slug を指定して記事のメタデータと Markdown 本文を取得したい, so that 記事詳細ページをレンダリングできる
+
+#### Acceptance Criteria
+
+1. When `GET /api/v1/notes/{noteSlug}` リクエストを受信した, the Note Detail API shall 該当記事のメタデータと Markdown 本文を JSON レスポンスとして返却する
+2. The Note Detail API shall レスポンスに id, title, slug, imageUrl, publishedOn, lastModifiedOn をメタデータとして含める
+3. The Note Detail API shall レスポンスの HTTP ステータスコードとして 200 を返却する
+4. The Note Detail API shall レスポンスの Content-Type として `application/json` を返却する
+
+### Requirement 2: Markdown 本文の mdast 変換
+
+**Objective:** As a フロントエンド開発者, I want Markdown 本文を mdast (Markdown Abstract Syntax Tree) 形式で受け取りたい, so that フロントエンドで柔軟にレンダリング制御できる
+
+#### Acceptance Criteria
+
+1. The Note Detail API shall Markdown 本文から frontmatter を除去した本文部分を mdast に変換してレスポンスに含める
+2. The Note Detail API shall mdast を `content` フィールドとしてレスポンスボディに含める
+3. The Note Detail API shall mdast の変換に unist/mdast 準拠のパーサーを使用する
+
+### Requirement 3: mdast 内の相対画像パス解決
+
+**Objective:** As a フロントエンド開発者, I want mdast 内の画像 URL がアセット配信 API を指すようにしたい, so that 記事内の画像をフロントエンドからそのまま表示できる
+
+#### Acceptance Criteria
+
+1. When mdast 内の image ノードの url が相対パスである, the Note Detail API shall そのパスをアセット配信 API のURL (`/api/v1/notes/{noteSlug}/assets/{assetPath}`) に解決する
+2. When mdast 内の image ノードの url が絶対 URL (http:// または https://) である, the Note Detail API shall そのURLを変更せずそのまま保持する
+3. The Note Detail API shall mdast ツリー全体を走査し、すべての image ノードの相対パスを解決する
+
+### Requirement 4: アセット配信
+
+**Objective:** As a フロントエンド開発者, I want 記事に紐づく画像等のアセットファイルを取得したい, so that 記事詳細ページ内の画像を表示できる
+
+#### Acceptance Criteria
+
+1. When `GET /api/v1/notes/{noteSlug}/assets/{assetPath}` リクエストを受信した, the Asset Delivery API shall 該当アセットのバイナリデータをレスポンスボディとして返却する
+2. The Asset Delivery API shall レスポンスの Content-Type にアセットの実際のメディアタイプ (例: `image/png`, `image/jpeg`) を設定する
+3. The Asset Delivery API shall レスポンスの HTTP ステータスコードとして 200 を返却する
+4. The Asset Delivery API shall アセットの ETag をレスポンスヘッダーに含める
+
+### Requirement 5: 記事が見つからない場合のエラーハンドリング
+
+**Objective:** As a フロントエンド開発者, I want 存在しない記事の slug を指定した場合に明確なエラーレスポンスを受け取りたい, so that クライアント側で適切にエラーハンドリングできる
+
+#### Acceptance Criteria
+
+1. If 指定された noteSlug に該当する記事がデータベースに存在しない, the Note Detail API shall HTTP ステータスコード 404 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+2. If 指定された noteSlug に該当する Markdown ファイルがストレージに存在しない, the Note Detail API shall HTTP ステータスコード 404 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+3. If 指定された noteSlug が不正な形式である, the Note Detail API shall HTTP ステータスコード 400 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+
+### Requirement 6: アセットが見つからない場合のエラーハンドリング
+
+**Objective:** As a フロントエンド開発者, I want 存在しないアセットパスを指定した場合に明確なエラーレスポンスを受け取りたい, so that クライアント側で適切にエラーハンドリングできる
+
+#### Acceptance Criteria
+
+1. If 指定された assetPath に該当するアセットがストレージに存在しない, the Asset Delivery API shall HTTP ステータスコード 404 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+2. If 指定された noteSlug が不正な形式である, the Asset Delivery API shall HTTP ステータスコード 400 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+
+### Requirement 7: エラーハンドリング共通
+
+**Objective:** As a フロントエンド開発者, I want 内部エラー時に一貫したエラーレスポンスを受け取りたい, so that エラー処理を統一的に実装できる
+
+#### Acceptance Criteria
+
+1. If ストレージまたはデータベースへのアクセス中にエラーが発生した, the Note Detail API shall HTTP ステータスコード 500 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+2. If 内部エラーが発生した, the Note Detail API shall エラーの詳細をサーバーログに出力する
+3. The Note Detail API shall エラーレスポンスの Content-Type として `application/problem+json` を返却する
+4. If ストレージまたはデータベースへのアクセス中にエラーが発生した, the Asset Delivery API shall HTTP ステータスコード 500 と RFC 9457 準拠の Problem Details エラーレスポンスを返却する
+5. The Asset Delivery API shall エラーレスポンスの Content-Type として `application/problem+json` を返却する
+
+### Requirement 8: レスポンス形式
+
+**Objective:** As a フロントエンド開発者, I want 一貫したレスポンス構造で記事詳細を受け取りたい, so that クライアント側での型安全なデータ処理が可能になる
+
+#### Acceptance Criteria
+
+1. The Note Detail API shall レスポンスボディを `{ id, title, slug, imageUrl, publishedOn, lastModifiedOn, content }` の構造で返却する
+2. The Note Detail API shall `content` フィールドに mdast ルートノード (type: "root") を含める
+3. The Note Detail API shall 日付フィールド (`publishedOn`, `lastModifiedOn`) を ISO 8601 形式の文字列として返却する
+
+### Requirement 9: 既存ルートグループへの統合
+
+**Objective:** As a バックエンド開発者, I want 既存の notes ルートグループにエンドポイントを追加したい, so that API の一貫性とコードの整理を維持できる
+
+#### Acceptance Criteria
+
+1. The Note Detail API shall 既存の `notesApp` Hono ルートグループ (`/api/v1/notes`) に `GET /:noteSlug` ハンドラとして追加される
+2. The Asset Delivery API shall 既存の `notesApp` Hono ルートグループに `GET /:noteSlug/assets/:assetPath` ハンドラとして追加される
+3. The Note Detail API shall 既存の `GET /api/v1/notes` (一覧) および `POST /api/v1/notes/refresh` エンドポイントに影響を与えない
+4. The Note Detail API shall 既存の `INoteQueryRepository`, `IMarkdownStorage`, `IAssetStorage` インターフェースを活用する

--- a/.kiro/specs/note-detail-api/requirements.md
+++ b/.kiro/specs/note-detail-api/requirements.md
@@ -1,0 +1,9 @@
+# Requirements Document
+
+## Project Description (Input)
+
+記事詳細 API (`GET /api/v1/notes/{noteSlug}`) の実装。記事メタデータに加え、Markdown 本文を mdast（Markdown Abstract Syntax Tree）形式で返す。mdast 内の相対画像パスはアセット配信 API (`GET /api/v1/notes/{noteSlug}/assets/{assetPath}`) の URL に解決する。
+
+## Requirements
+
+<!-- Will be generated in /kiro:spec-requirements phase -->

--- a/.kiro/specs/note-detail-api/requirements.md
+++ b/.kiro/specs/note-detail-api/requirements.md
@@ -3,6 +3,7 @@
 ## Introduction
 
 記事詳細 API の要件定義書。2つの API エンドポイントを定義する。
+
 1. **記事詳細 API** (`GET /api/v1/notes/{noteSlug}`) -- 記事のメタデータに加え、Markdown 本文を mdast (Markdown Abstract Syntax Tree) 形式で返す。mdast 内の相対画像パスはアセット配信 API の URL に解決する。
 2. **アセット配信 API** (`GET /api/v1/notes/{noteSlug}/assets/{assetPath}`) -- 記事に紐づく画像等のアセットファイルをバイナリストリームとして配信する。
 

--- a/.kiro/specs/note-detail-api/research.md
+++ b/.kiro/specs/note-detail-api/research.md
@@ -1,0 +1,120 @@
+# Research & Design Decisions
+
+---
+
+**Purpose**: 記事詳細 API (note-detail-api) の設計判断に至る調査結果と根拠を記録する。
+
+---
+
+## Summary
+
+- **Feature**: `note-detail-api`
+- **Discovery Scope**: Extension
+- **Key Findings**:
+  - `remark-parse` (v11) と `remark-frontmatter` (v5) は既にプロジェクトに導入済みであり、Markdown から mdast への変換に追加依存なく対応可能
+  - `unist-util-visit` (v5) を新規追加することで mdast ツリーの image ノード走査を型安全に実装できる
+  - 既存の `IAssetStorage`、`IMarkdownStorage`、`INoteQueryRepository` インターフェースが記事詳細・アセット配信の両方に十分な API を提供している
+
+## Research Log
+
+### Markdown から mdast への変換パイプライン
+
+- **Context**: 要件 2 で Markdown 本文を mdast 形式に変換する必要がある
+- **Sources Consulted**:
+  - [remark-parse (npm)](https://www.npmjs.com/package/remark-parse)
+  - [unified (GitHub)](https://github.com/unifiedjs/unified)
+  - [remark-frontmatter (npm)](https://www.npmjs.com/package/remark-frontmatter)
+- **Findings**:
+  - `unified` + `remark-parse` で Markdown 文字列を mdast `Root` ノードに変換可能
+  - `remark-frontmatter` プラグインを使用すると frontmatter を YAML ノードとして認識し、mdast ツリーから除去可能
+  - プロジェクトの `package.json` には `unified@^11.0.5`、`remark-parse@^11.0.0`、`remark-frontmatter@^5.0.0` が既に存在
+- **Implications**: 新規パッケージの追加は `unist-util-visit` と `@types/mdast` のみで済む
+
+### mdast 内の画像パス解決
+
+- **Context**: 要件 3 で mdast 内の相対画像パスをアセット配信 API の URL に解決する必要がある
+- **Sources Consulted**:
+  - [unist-util-visit (npm)](https://www.npmjs.com/package/unist-util-visit)
+  - [mdast specification (GitHub)](https://github.com/syntax-tree/mdast)
+  - [@types/mdast (npm)](https://www.npmjs.com/package/@types/mdast)
+- **Findings**:
+  - mdast の `Image` ノードは `url`, `alt`, `title` プロパティを持つ
+  - `unist-util-visit` v5 は ESM のみ、TypeScript 完全対応、`visit(tree, 'image', visitor)` で型安全に image ノードのみ走査可能
+  - 相対パスの判定は `url` が `http://` または `https://` で始まらないことで判定できる
+- **Implications**: `unist-util-visit` を依存に追加し、ドメインレイヤーに mdast 変換ロジックを配置する
+
+### 既存 R2 ストレージのキー構造
+
+- **Context**: アセット配信 API で R2 からアセットを取得する際のキー構造を理解する必要がある
+- **Sources Consulted**: `app/backend/infra/r2/note/asset.storage.ts` (既存実装)
+- **Findings**:
+  - R2 のキープレフィックスは `notes/` で、アセットは `notes/{slug}/{assetPath}` の形式で格納されている
+  - `IAssetStorage.get(objectKey)` は `ObjectKey` を受け取り、内部で `notes/` プレフィックスを付与する
+  - つまり `ObjectKey.create("{slug}/{assetPath}")` でアセットにアクセス可能
+- **Implications**: ハンドラ層で `noteSlug` と `assetPath` を連結して `ObjectKey` を構築する
+
+### MarkdownContent の ReadableStream 処理
+
+- **Context**: `IMarkdownStorage.get()` は `ReadableStream` を返すが、mdast 変換には文字列が必要
+- **Sources Consulted**: 既存実装の `notes-refresh.service.ts`
+- **Findings**:
+  - `ReadableStream` をテキストに変換するため `new Response(stream).text()` パターンが利用可能
+  - Cloudflare Workers 環境では Web Streams API が標準で利用可能
+- **Implications**: ユースケース層で `ReadableStream` を文字列に変換してから mdast パーサーに渡す
+
+## Architecture Pattern Evaluation
+
+| Option | Description | Strengths | Risks / Limitations | Notes |
+| --- | --- | --- | --- | --- |
+| UseCase パターン (採用) | 既存の `ListNotesUseCase` と同様にドメインユースケースクラスを追加 | 既存パターンとの一貫性、テスト容易性 | 追加クラスが増える | 既存アーキテクチャに完全準拠 |
+| Service パターン | `NotesRefreshService` のようにサービス層にロジックを配置 | 複合操作に適する | 既存の UseCase パターンと不整合 | 本機能は単一集約への問い合わせなので UseCase が適切 |
+
+## Design Decisions
+
+### Decision: mdast 変換ロジックの配置
+
+- **Context**: Markdown 本文を mdast に変換し、画像パスを解決するロジックの配置場所
+- **Alternatives Considered**:
+  1. ハンドラ層に直接配置 -- 実装は単純だがテスト困難
+  2. サービス層に配置 -- 既存の RefreshService と同列
+  3. ドメイン層のユースケースに配置 -- 既存パターン準拠
+- **Selected Approach**: ドメイン層に mdast 変換関数を配置し、ユースケースから呼び出す
+- **Rationale**: 既存の `parseNoteContent` 関数がドメイン層に配置されている前例に倣い、Markdown 処理ロジックはドメインに属する。ユースケースがストレージからの取得と mdast 変換を組み合わせる
+- **Trade-offs**: ドメイン層が `unified`/`remark-parse` に依存するが、これは既に `vfile`/`vfile-matter` への依存があるため許容範囲
+- **Follow-up**: ドメインレイヤーのインターフェース名に技術固有名称を含めないことを確認
+
+### Decision: frontmatter 除去の方法
+
+- **Context**: mdast に変換する際に frontmatter を除去する方法
+- **Alternatives Considered**:
+  1. 文字列レベルで `---` 区切りを除去してからパース
+  2. `remark-frontmatter` プラグインで YAML ノードとしてパースし、mdast ツリーから除外
+- **Selected Approach**: `remark-frontmatter` プラグインを使用して frontmatter を認識させつつ、変換後のツリーから YAML ノードを除外する
+- **Rationale**: 既にプロジェクトに導入済みのプラグインを活用でき、文字列操作よりも堅牢。`remark-frontmatter` は frontmatter を専用の YAML ノードとして解析するため、ツリーからフィルタリングするだけで除去可能
+- **Trade-offs**: YAML ノードのフィルタリングが必要だが、`unified` のプラグインパイプラインに `remarkFrontmatter` を追加するだけで frontmatter を分離できる
+
+### Decision: アセットパスの構築
+
+- **Context**: `GET /api/v1/notes/{noteSlug}/assets/{assetPath}` で受け取ったパスパラメータから R2 オブジェクトキーを構築する方法
+- **Alternatives Considered**:
+  1. ハンドラ層で直接 `ObjectKey.create()` を呼び出す
+  2. ドメイン層に専用のファクトリメソッドを追加
+- **Selected Approach**: ハンドラ層で `{noteSlug}/{assetPath}` を連結して `ObjectKey.create()` を呼び出す
+- **Rationale**: `AssetStorage` の実装が `notes/` プレフィックスを自動付与するため、slug とパスの連結はシンプルな文字列操作で十分。ドメイン層に余計な抽象化を追加する必要はない
+- **Trade-offs**: ハンドラ層にキー構築の知識が漏れるが、複雑性が低いため許容
+
+## Risks & Mitigations
+
+- **Risk**: `ReadableStream` から文字列への変換でメモリを消費する大きな Markdown ファイル -- **Mitigation**: 実用上、記事の Markdown ファイルは数十 KB 程度であり問題にならない。将来的にサイズ制限を検討
+- **Risk**: mdast の構造が unified/remark のバージョンアップで変わる可能性 -- **Mitigation**: `@types/mdast` で型を固定し、テストで mdast 構造を検証
+- **Risk**: Hono のルートパラメータ `/:noteSlug/assets/:assetPath` でスラッシュを含むパスが正しく取得できない可能性 -- **Mitigation**: Hono v4 ではワイルドカードパラメータ (`*`) でスラッシュを含むパスをキャプチャ可能。`/:noteSlug/assets/*` パターンの使用を検討
+
+## References
+
+- [remark-parse (npm)](https://www.npmjs.com/package/remark-parse) -- Markdown パーサー
+- [unified (GitHub)](https://github.com/unifiedjs/unified) -- コンテンツ変換フレームワーク
+- [mdast specification (GitHub)](https://github.com/syntax-tree/mdast) -- Markdown AST 仕様
+- [@types/mdast (npm)](https://www.npmjs.com/package/@types/mdast) -- mdast TypeScript 型定義
+- [unist-util-visit (npm)](https://www.npmjs.com/package/unist-util-visit) -- unist ツリー走査ユーティリティ
+- [remark-frontmatter (npm)](https://www.npmjs.com/package/remark-frontmatter) -- frontmatter パーサープラグイン
+- [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) -- エラーレスポンス標準

--- a/.kiro/specs/note-detail-api/research.md
+++ b/.kiro/specs/note-detail-api/research.md
@@ -64,10 +64,10 @@
 
 ## Architecture Pattern Evaluation
 
-| Option | Description | Strengths | Risks / Limitations | Notes |
-| --- | --- | --- | --- | --- |
-| UseCase パターン (採用) | 既存の `ListNotesUseCase` と同様にドメインユースケースクラスを追加 | 既存パターンとの一貫性、テスト容易性 | 追加クラスが増える | 既存アーキテクチャに完全準拠 |
-| Service パターン | `NotesRefreshService` のようにサービス層にロジックを配置 | 複合操作に適する | 既存の UseCase パターンと不整合 | 本機能は単一集約への問い合わせなので UseCase が適切 |
+| Option                  | Description                                                        | Strengths                            | Risks / Limitations             | Notes                                               |
+| ----------------------- | ------------------------------------------------------------------ | ------------------------------------ | ------------------------------- | --------------------------------------------------- |
+| UseCase パターン (採用) | 既存の `ListNotesUseCase` と同様にドメインユースケースクラスを追加 | 既存パターンとの一貫性、テスト容易性 | 追加クラスが増える              | 既存アーキテクチャに完全準拠                        |
+| Service パターン        | `NotesRefreshService` のようにサービス層にロジックを配置           | 複合操作に適する                     | 既存の UseCase パターンと不整合 | 本機能は単一集約への問い合わせなので UseCase が適切 |
 
 ## Design Decisions
 

--- a/.kiro/specs/note-detail-api/spec.json
+++ b/.kiro/specs/note-detail-api/spec.json
@@ -3,14 +3,14 @@
   "created_at": "2026-02-20T00:00:00.000Z",
   "updated_at": "2026-02-20T00:00:00.000Z",
   "language": "ja",
-  "phase": "requirements-generated",
+  "phase": "design-generated",
   "approvals": {
     "requirements": {
       "generated": true,
-      "approved": false
+      "approved": true
     },
     "design": {
-      "generated": false,
+      "generated": true,
       "approved": false
     },
     "tasks": {

--- a/.kiro/specs/note-detail-api/spec.json
+++ b/.kiro/specs/note-detail-api/spec.json
@@ -3,10 +3,10 @@
   "created_at": "2026-02-20T00:00:00.000Z",
   "updated_at": "2026-02-20T00:00:00.000Z",
   "language": "ja",
-  "phase": "initialized",
+  "phase": "requirements-generated",
   "approvals": {
     "requirements": {
-      "generated": false,
+      "generated": true,
       "approved": false
     },
     "design": {

--- a/.kiro/specs/note-detail-api/spec.json
+++ b/.kiro/specs/note-detail-api/spec.json
@@ -3,7 +3,7 @@
   "created_at": "2026-02-20T00:00:00.000Z",
   "updated_at": "2026-02-20T00:00:00.000Z",
   "language": "ja",
-  "phase": "tasks-generated",
+  "phase": "implementation",
   "approvals": {
     "requirements": {
       "generated": true,
@@ -15,8 +15,8 @@
     },
     "tasks": {
       "generated": true,
-      "approved": false
+      "approved": true
     }
   },
-  "ready_for_implementation": false
+  "ready_for_implementation": true
 }

--- a/.kiro/specs/note-detail-api/spec.json
+++ b/.kiro/specs/note-detail-api/spec.json
@@ -3,7 +3,7 @@
   "created_at": "2026-02-20T00:00:00.000Z",
   "updated_at": "2026-02-20T00:00:00.000Z",
   "language": "ja",
-  "phase": "design-generated",
+  "phase": "tasks-generated",
   "approvals": {
     "requirements": {
       "generated": true,
@@ -11,10 +11,10 @@
     },
     "design": {
       "generated": true,
-      "approved": false
+      "approved": true
     },
     "tasks": {
-      "generated": false,
+      "generated": true,
       "approved": false
     }
   },

--- a/.kiro/specs/note-detail-api/spec.json
+++ b/.kiro/specs/note-detail-api/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "note-detail-api",
+  "created_at": "2026-02-20T00:00:00.000Z",
+  "updated_at": "2026-02-20T00:00:00.000Z",
+  "language": "ja",
+  "phase": "initialized",
+  "approvals": {
+    "requirements": {
+      "generated": false,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}

--- a/.kiro/specs/note-detail-api/tasks.md
+++ b/.kiro/specs/note-detail-api/tasks.md
@@ -1,27 +1,27 @@
 # Implementation Plan
 
-- [ ] 1. 依存パッケージの追加
+- [x] 1. 依存パッケージの追加
   - mdast ツリー走査に必要な `unist-util-visit` を dependencies に追加する
   - mdast の型定義 `@types/mdast` を devDependencies に追加する
   - パッケージインストール後、既存テストとビルドが正常に通ることを確認する
   - _Requirements: 2.3, 3.3_
 
-- [ ] 2. ドメイン層のエラークラスとレスポンス型の追加
-- [ ] 2.1 (P) ドメインエラークラスの追加
+- [x] 2. ドメイン層のエラークラスとレスポンス型の追加
+- [x] 2.1 (P) ドメインエラークラスの追加
   - 記事が DB に存在しない場合を表す `NoteNotFoundError` を既存のエラーファイルに追加する
   - Markdown ファイルがストレージに存在しない場合を表す `MarkdownNotFoundError` を追加する
   - 各エラークラスは slug を受け取り、明確なメッセージを持つ
   - TDD: 各エラークラスのインスタンス化とプロパティを検証するテストを先に書く
   - _Requirements: 5.1, 5.2_
 
-- [ ] 2.2 (P) 記事詳細レスポンス型の定義
+- [x] 2.2 (P) 記事詳細レスポンス型の定義
   - 記事詳細 API のレスポンス構造を表す型を共有型ファイルに追加する
   - id, title, slug, imageUrl, publishedOn, lastModifiedOn のメタデータフィールドと、mdast Root ノードを含む content フィールドを定義する
   - 日付フィールドは ISO 8601 形式の文字列型とする
   - _Requirements: 1.2, 8.1, 8.2, 8.3_
 
-- [ ] 3. Markdown から mdast への変換機能
-- [ ] 3.1 相対画像パスをアセット配信 API の URL に解決する関数を実装する
+- [x] 3. Markdown から mdast への変換機能
+- [x] 3.1 相対画像パスをアセット配信 API の URL に解決する関数を実装する
   - mdast ツリー全体を走査し、image ノードを検出する
   - 相対パス (http:// または https:// で始まらない URL) をアセット配信 API のパス (`/api/v1/notes/{slug}/assets/{path}`) に変換する
   - 絶対 URL はそのまま保持する
@@ -29,7 +29,7 @@
   - TDD: 相対パス変換、絶対 URL 保持、image ノードなしのパススルー、ネストされた image ノードの走査を検証するテストを先に書く
   - _Requirements: 3.1, 3.2, 3.3_
 
-- [ ] 3.2 Markdown 文字列を mdast Root ノードに変換する関数を実装する
+- [x] 3.2 Markdown 文字列を mdast Root ノードに変換する関数を実装する
   - unified + remark-parse + remark-frontmatter パイプラインで Markdown をパースする
   - パース後のツリーから frontmatter (YAML ノード) を除外する
   - 画像パス解決関数を呼び出して相対画像パスをアセット API URL に変換する
@@ -38,7 +38,7 @@
   - 3.1 の画像パス解決関数に依存するため、3.1 完了後に実装する
   - _Requirements: 2.1, 2.2, 2.3, 8.2_
 
-- [ ] 4. 記事詳細取得ユースケースの実装
+- [x] 4. 記事詳細取得ユースケースの実装
   - slug を受け取り、クエリリポジトリからメタデータ、Markdown ストレージから本文を取得する
   - ReadableStream を文字列に変換し、mdast 変換関数を呼び出す
   - メタデータと mdast を組み合わせた結果オブジェクトを返す
@@ -48,8 +48,8 @@
   - TDD: 正常系のレスポンス構造検証、NoteNotFoundError と MarkdownNotFoundError のスロー検証をモックを使ったテストで先に書く
   - _Requirements: 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4_
 
-- [ ] 5. ハンドラ層の実装と既存ルートグループへの統合
-- [ ] 5.1 記事詳細ハンドラの実装
+- [x] 5. ハンドラ層の実装と既存ルートグループへの統合
+- [x] 5.1 記事詳細ハンドラの実装
   - 既存の notesApp ルートグループに `GET /:noteSlug` エンドポイントを追加する
   - パスパラメータの slug を NoteSlug で検証し、不正な場合は 400 ProblemDetails を返す
   - ユースケースを呼び出し、結果を JSON レスポンスとして返す
@@ -59,7 +59,7 @@
   - TDD: 正常レスポンス、400 (不正 slug)、404 (記事なし / Markdown なし)、500 (内部エラー) のケースをテストで先に書く
   - _Requirements: 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3_
 
-- [ ] 5.2 アセット配信ハンドラの実装
+- [x] 5.2 アセット配信ハンドラの実装
   - 既存の notesApp ルートグループに `GET /:noteSlug/assets/*` エンドポイントを追加する
   - パスパラメータの slug を NoteSlug で検証し、不正な場合は 400 ProblemDetails を返す
   - slug とアセットパスを連結して ObjectKey を構築し、IAssetStorage から取得する
@@ -69,7 +69,7 @@
   - TDD: バイナリストリーム返却、Content-Type 設定、ETag ヘッダー、404 (アセットなし)、400 (不正 slug)、500 (内部エラー) のケースをテストで先に書く
   - _Requirements: 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3_
 
-- [ ] 6. 統合検証
+- [x] 6. 統合検証
   - 既存の `GET /api/v1/notes` (一覧) エンドポイントが引き続き正常動作することを確認する
   - 既存の `POST /api/v1/notes/refresh` (再構築) エンドポイントが引き続き正常動作することを確認する
   - 記事詳細 API とアセット配信 API のルートが互いに干渉しないことを確認する

--- a/.kiro/specs/note-detail-api/tasks.md
+++ b/.kiro/specs/note-detail-api/tasks.md
@@ -1,0 +1,78 @@
+# Implementation Plan
+
+- [ ] 1. 依存パッケージの追加
+  - mdast ツリー走査に必要な `unist-util-visit` を dependencies に追加する
+  - mdast の型定義 `@types/mdast` を devDependencies に追加する
+  - パッケージインストール後、既存テストとビルドが正常に通ることを確認する
+  - _Requirements: 2.3, 3.3_
+
+- [ ] 2. ドメイン層のエラークラスとレスポンス型の追加
+- [ ] 2.1 (P) ドメインエラークラスの追加
+  - 記事が DB に存在しない場合を表す `NoteNotFoundError` を既存のエラーファイルに追加する
+  - Markdown ファイルがストレージに存在しない場合を表す `MarkdownNotFoundError` を追加する
+  - 各エラークラスは slug を受け取り、明確なメッセージを持つ
+  - TDD: 各エラークラスのインスタンス化とプロパティを検証するテストを先に書く
+  - _Requirements: 5.1, 5.2_
+
+- [ ] 2.2 (P) 記事詳細レスポンス型の定義
+  - 記事詳細 API のレスポンス構造を表す型を共有型ファイルに追加する
+  - id, title, slug, imageUrl, publishedOn, lastModifiedOn のメタデータフィールドと、mdast Root ノードを含む content フィールドを定義する
+  - 日付フィールドは ISO 8601 形式の文字列型とする
+  - _Requirements: 1.2, 8.1, 8.2, 8.3_
+
+- [ ] 3. Markdown から mdast への変換機能
+- [ ] 3.1 相対画像パスをアセット配信 API の URL に解決する関数を実装する
+  - mdast ツリー全体を走査し、image ノードを検出する
+  - 相対パス (http:// または https:// で始まらない URL) をアセット配信 API のパス (`/api/v1/notes/{slug}/assets/{path}`) に変換する
+  - 絶対 URL はそのまま保持する
+  - 元のツリーを変更せず、新しいツリーを返す純粋関数として実装する
+  - TDD: 相対パス変換、絶対 URL 保持、image ノードなしのパススルー、ネストされた image ノードの走査を検証するテストを先に書く
+  - _Requirements: 3.1, 3.2, 3.3_
+
+- [ ] 3.2 Markdown 文字列を mdast Root ノードに変換する関数を実装する
+  - unified + remark-parse + remark-frontmatter パイプラインで Markdown をパースする
+  - パース後のツリーから frontmatter (YAML ノード) を除外する
+  - 画像パス解決関数を呼び出して相対画像パスをアセット API URL に変換する
+  - 純粋関数として設計し、slug を受け取って画像パスの解決に使用する
+  - TDD: frontmatter 除去、mdast Root ノード生成、空 Markdown の処理、画像パス解決の統合を検証するテストを先に書く
+  - 3.1 の画像パス解決関数に依存するため、3.1 完了後に実装する
+  - _Requirements: 2.1, 2.2, 2.3, 8.2_
+
+- [ ] 4. 記事詳細取得ユースケースの実装
+  - slug を受け取り、クエリリポジトリからメタデータ、Markdown ストレージから本文を取得する
+  - ReadableStream を文字列に変換し、mdast 変換関数を呼び出す
+  - メタデータと mdast を組み合わせた結果オブジェクトを返す
+  - 日付フィールドは ISO 8601 形式の文字列に変換する
+  - 記事が DB に存在しない場合は NoteNotFoundError をスローする
+  - Markdown がストレージに存在しない場合は MarkdownNotFoundError をスローする
+  - TDD: 正常系のレスポンス構造検証、NoteNotFoundError と MarkdownNotFoundError のスロー検証をモックを使ったテストで先に書く
+  - _Requirements: 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 8.1, 8.3, 9.4_
+
+- [ ] 5. ハンドラ層の実装と既存ルートグループへの統合
+- [ ] 5.1 記事詳細ハンドラの実装
+  - 既存の notesApp ルートグループに `GET /:noteSlug` エンドポイントを追加する
+  - パスパラメータの slug を NoteSlug で検証し、不正な場合は 400 ProblemDetails を返す
+  - ユースケースを呼び出し、結果を JSON レスポンスとして返す
+  - ドメイン例外 (NoteNotFoundError, MarkdownNotFoundError) を 404 ProblemDetails に変換する
+  - 内部エラーは console.error でログ出力し、500 ProblemDetails を返す
+  - ルート定義順序は既存の `/` と `/refresh` の後に配置し、競合を防ぐ
+  - TDD: 正常レスポンス、400 (不正 slug)、404 (記事なし / Markdown なし)、500 (内部エラー) のケースをテストで先に書く
+  - _Requirements: 1.1, 1.3, 1.4, 5.1, 5.2, 5.3, 7.1, 7.2, 7.3, 9.1, 9.3_
+
+- [ ] 5.2 アセット配信ハンドラの実装
+  - 既存の notesApp ルートグループに `GET /:noteSlug/assets/*` エンドポイントを追加する
+  - パスパラメータの slug を NoteSlug で検証し、不正な場合は 400 ProblemDetails を返す
+  - slug とアセットパスを連結して ObjectKey を構築し、IAssetStorage から取得する
+  - アセットが見つからない場合は 404 ProblemDetails を返す
+  - レスポンスにバイナリストリーム、Content-Type、ETag ヘッダーを設定する
+  - 内部エラーは console.error でログ出力し、500 ProblemDetails を返す
+  - TDD: バイナリストリーム返却、Content-Type 設定、ETag ヘッダー、404 (アセットなし)、400 (不正 slug)、500 (内部エラー) のケースをテストで先に書く
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 6.1, 6.2, 7.4, 7.5, 9.2, 9.3_
+
+- [ ] 6. 統合検証
+  - 既存の `GET /api/v1/notes` (一覧) エンドポイントが引き続き正常動作することを確認する
+  - 既存の `POST /api/v1/notes/refresh` (再構築) エンドポイントが引き続き正常動作することを確認する
+  - 記事詳細 API とアセット配信 API のルートが互いに干渉しないことを確認する
+  - 全エラーレスポンスの Content-Type が `application/problem+json` であることを確認する
+  - 型チェック、リント、既存テストを含む全品質ゲートを通過させる
+  - _Requirements: 9.1, 9.2, 9.3, 9.4, 7.3, 7.5_

--- a/app/backend/domain/note/errors.test.ts
+++ b/app/backend/domain/note/errors.test.ts
@@ -3,7 +3,9 @@ import {
   InvalidImageUrlError,
   InvalidNoteSlugError,
   InvalidNoteTitleError,
+  MarkdownNotFoundError,
   NoteMetadataValidationError,
+  NoteNotFoundError,
   NoteParseError,
 } from "./errors";
 
@@ -64,5 +66,27 @@ describe("InvalidImageUrlError", () => {
     expect(error.name).toBe("InvalidImageUrlError");
     expect(error.message).toContain("not-a-url");
     expect(error.value).toBe("not-a-url");
+  });
+});
+
+describe("NoteNotFoundError", () => {
+  it("slug を含むエラーメッセージを生成する", () => {
+    const error = new NoteNotFoundError("my-article");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("NoteNotFoundError");
+    expect(error.message).toContain("my-article");
+    expect(error.slug).toBe("my-article");
+  });
+});
+
+describe("MarkdownNotFoundError", () => {
+  it("slug を含むエラーメッセージを生成する", () => {
+    const error = new MarkdownNotFoundError("my-article");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("MarkdownNotFoundError");
+    expect(error.message).toContain("my-article");
+    expect(error.slug).toBe("my-article");
   });
 });

--- a/app/backend/domain/note/errors.ts
+++ b/app/backend/domain/note/errors.ts
@@ -30,6 +30,22 @@ export class InvalidImageUrlError extends Error {
   }
 }
 
+export class NoteNotFoundError extends Error {
+  readonly name = "NoteNotFoundError" as const;
+
+  constructor(readonly slug: string) {
+    super(`Note not found: ${slug}`);
+  }
+}
+
+export class MarkdownNotFoundError extends Error {
+  readonly name = "MarkdownNotFoundError" as const;
+
+  constructor(readonly slug: string) {
+    super(`Markdown not found: ${slug}`);
+  }
+}
+
 export class NoteMetadataValidationError extends Error {
   readonly name = "NoteMetadataValidationError" as const;
 

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -26,6 +26,16 @@ describe("ImageUrl Value Object", () => {
       );
     });
 
+    it("should create an ImageUrl with an absolute path", () => {
+      const imageUrl = ImageUrl.create(
+        "/api/v1/notes/my-article/assets/cover.png",
+      );
+
+      expect(imageUrl.value).toBe(
+        "/api/v1/notes/my-article/assets/cover.png",
+      );
+    });
+
     it("should throw an error for an empty string", () => {
       expect(() => ImageUrl.create("")).toThrow(InvalidImageUrlError);
     });

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -31,9 +31,7 @@ describe("ImageUrl Value Object", () => {
         "/api/v1/notes/my-article/assets/cover.png",
       );
 
-      expect(imageUrl.value).toBe(
-        "/api/v1/notes/my-article/assets/cover.png",
-      );
+      expect(imageUrl.value).toBe("/api/v1/notes/my-article/assets/cover.png");
     });
 
     it("should throw an error for an empty string", () => {

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -23,6 +23,9 @@ export class ImageUrl implements IValueObject<ImageUrl> {
     if (value.length === 0) {
       return false;
     }
+    if (value.startsWith("/")) {
+      return true;
+    }
     try {
       new URL(value);
       return true;

--- a/app/backend/domain/note/markdown-to-mdast.test.ts
+++ b/app/backend/domain/note/markdown-to-mdast.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { markdownToMdast } from "./markdown-to-mdast";
+import { NoteSlug } from "./note-slug.vo";
+import type { Image, Paragraph, Root } from "mdast";
+
+const slug = NoteSlug.create("my-article");
+
+describe("markdownToMdast", () => {
+  it("Markdown 文字列を mdast Root ノードに変換する", () => {
+    const content = `# Hello
+
+This is a paragraph.
+`;
+
+    const result = markdownToMdast(content, slug);
+
+    expect(result.type).toBe("root");
+    expect(result.children.length).toBeGreaterThan(0);
+    expect(result.children[0].type).toBe("heading");
+  });
+
+  it("frontmatter (YAML ノード) を除去する", () => {
+    const content = `---
+title: "My Article"
+publishedOn: "2026-01-15"
+---
+
+# Hello
+
+Paragraph text.
+`;
+
+    const result = markdownToMdast(content, slug);
+
+    const hasYamlNode = result.children.some((child) => child.type === "yaml");
+    expect(hasYamlNode).toBe(false);
+
+    expect(result.children[0].type).toBe("heading");
+  });
+
+  it("空の Markdown を処理して空の Root ノードを返す", () => {
+    const content = "";
+
+    const result = markdownToMdast(content, slug);
+
+    expect(result.type).toBe("root");
+    expect(result.children).toEqual([]);
+  });
+
+  it("mdast Root ノードの type が 'root' である", () => {
+    const content = "Some text.";
+
+    const result: Root = markdownToMdast(content, slug);
+
+    expect(result.type).toBe("root");
+  });
+
+  it("相対画像パスをアセット配信 API の URL に変換する", () => {
+    const content = `# Article
+
+![Diagram](images/diagram.png)
+`;
+
+    const result = markdownToMdast(content, slug);
+
+    const paragraph = result.children.find(
+      (child) => child.type === "paragraph",
+    ) as Paragraph;
+    expect(paragraph).toBeDefined();
+
+    const image = paragraph.children.find(
+      (child) => child.type === "image",
+    ) as Image;
+    expect(image).toBeDefined();
+    expect(image.url).toBe(
+      "/api/v1/notes/my-article/assets/images/diagram.png",
+    );
+  });
+
+  it("絶対 URL の画像はそのまま保持する", () => {
+    const content = `![Photo](https://example.com/photo.jpg)`;
+
+    const result = markdownToMdast(content, slug);
+
+    const paragraph = result.children[0] as Paragraph;
+    const image = paragraph.children[0] as Image;
+    expect(image.url).toBe("https://example.com/photo.jpg");
+  });
+
+  it("frontmatter のみの Markdown を処理する", () => {
+    const content = `---
+title: "Only frontmatter"
+---
+`;
+
+    const result = markdownToMdast(content, slug);
+
+    expect(result.type).toBe("root");
+    const hasYamlNode = result.children.some((child) => child.type === "yaml");
+    expect(hasYamlNode).toBe(false);
+  });
+
+  it("コードブロックや他のノードタイプを正しくパースする", () => {
+    const content = `# Heading
+
+Some text with **bold** and *italic*.
+
+- Item 1
+- Item 2
+`;
+
+    const result = markdownToMdast(content, slug);
+
+    const types = result.children.map((child) => child.type);
+    expect(types).toContain("heading");
+    expect(types).toContain("paragraph");
+    expect(types).toContain("list");
+  });
+});

--- a/app/backend/domain/note/markdown-to-mdast.ts
+++ b/app/backend/domain/note/markdown-to-mdast.ts
@@ -1,0 +1,21 @@
+import remarkFrontmatter from "remark-frontmatter";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { resolveImageUrls } from "./resolve-image-urls";
+import type { NoteSlug } from "./note-slug.vo";
+import type { Root, RootContent } from "mdast";
+
+const parser = unified().use(remarkParse).use(remarkFrontmatter, ["yaml"]);
+
+const isNotYamlNode = (node: RootContent): boolean => node.type !== "yaml";
+
+export function markdownToMdast(content: string, slug: NoteSlug): Root {
+  const tree = parser.parse(content);
+
+  const filteredTree: Root = {
+    ...tree,
+    children: tree.children.filter((node) => isNotYamlNode(node)),
+  };
+
+  return resolveImageUrls(filteredTree, slug);
+}

--- a/app/backend/domain/note/note-content.parser.test.ts
+++ b/app/backend/domain/note/note-content.parser.test.ts
@@ -36,6 +36,66 @@ lastModifiedOn: "2025-02-01"
     ).toBe(true);
   });
 
+  it("相対パスの imageUrl をアセット API URL に解決する", () => {
+    const content = `---
+title: "テスト記事"
+imageUrl: "./cover.png"
+publishedOn: "2025-01-15"
+lastModifiedOn: "2025-02-01"
+---
+
+# 本文
+`;
+
+    const metadata = parseNoteContent(content, slug);
+
+    expect(
+      metadata.imageUrl.equals(
+        ImageUrl.create("/api/v1/notes/my-article/assets/cover.png"),
+      ),
+    ).toBe(true);
+  });
+
+  it("'./' なしの相対パスの imageUrl もアセット API URL に解決する", () => {
+    const content = `---
+title: "テスト記事"
+imageUrl: "images/hero.jpg"
+publishedOn: "2025-01-15"
+lastModifiedOn: "2025-02-01"
+---
+
+# 本文
+`;
+
+    const metadata = parseNoteContent(content, slug);
+
+    expect(
+      metadata.imageUrl.equals(
+        ImageUrl.create("/api/v1/notes/my-article/assets/images/hero.jpg"),
+      ),
+    ).toBe(true);
+  });
+
+  it("絶対 URL の imageUrl はそのまま保持する", () => {
+    const content = `---
+title: "テスト記事"
+imageUrl: "https://example.com/image.png"
+publishedOn: "2025-01-15"
+lastModifiedOn: "2025-02-01"
+---
+
+# 本文
+`;
+
+    const metadata = parseNoteContent(content, slug);
+
+    expect(
+      metadata.imageUrl.equals(
+        ImageUrl.create("https://example.com/image.png"),
+      ),
+    ).toBe(true);
+  });
+
   it("必須フィールドが欠落している場合に NoteMetadataValidationError をスローする", () => {
     const content = `---
 title: "タイトルのみ"

--- a/app/backend/domain/note/note-content.parser.ts
+++ b/app/backend/domain/note/note-content.parser.ts
@@ -6,6 +6,15 @@ import { ImageUrl } from "./image-url.vo";
 import { NoteTitle } from "./note-title.vo";
 import type { NoteSlug } from "./note-slug.vo";
 
+const isAbsoluteUrl = (url: string): boolean =>
+  url.startsWith("http://") || url.startsWith("https://");
+
+const resolveImageUrl = (url: string, slug: NoteSlug): string => {
+  if (isAbsoluteUrl(url)) return url;
+  const normalized = url.startsWith("./") ? url.slice(2) : url;
+  return `/api/v1/notes/${slug.value}/assets/${normalized}`;
+};
+
 export type NoteMetadata = {
   readonly title: NoteTitle;
   readonly imageUrl: ImageUrl;
@@ -52,7 +61,7 @@ export function parseNoteContent(
 
   return {
     title: NoteTitle.create(String(title)),
-    imageUrl: ImageUrl.create(String(imageUrl)),
+    imageUrl: ImageUrl.create(resolveImageUrl(String(imageUrl), slug)),
     publishedOn: Temporal.PlainDate.from(String(publishedOn)),
     lastModifiedOn: Temporal.PlainDate.from(String(lastModifiedOn)),
   };

--- a/app/backend/domain/note/resolve-image-urls.test.ts
+++ b/app/backend/domain/note/resolve-image-urls.test.ts
@@ -172,6 +172,33 @@ describe("resolveImageUrls", () => {
     expect(originalImage.url).toBe("photo.png");
   });
 
+  it("'./' プレフィックス付きの相対パスを正規化して変換する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "./hero.png",
+              alt: "Hero",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const paragraph = result.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe("/api/v1/notes/my-article/assets/hero.png");
+  });
+
   it("複数の image ノードを含むツリーですべて変換する", () => {
     const tree: Root = {
       type: "root",

--- a/app/backend/domain/note/resolve-image-urls.test.ts
+++ b/app/backend/domain/note/resolve-image-urls.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { NoteSlug } from "./note-slug.vo";
+import { resolveImageUrls } from "./resolve-image-urls";
+import type { Root } from "mdast";
+
+const slug = NoteSlug.create("my-article");
+
+describe("resolveImageUrls", () => {
+  it("相対パスの画像 URL をアセット配信 API の URL に変換する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "images/diagram.png",
+              alt: "Diagram",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const paragraph = result.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe(
+      "/api/v1/notes/my-article/assets/images/diagram.png",
+    );
+  });
+
+  it("絶対 URL (https://) はそのまま保持する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "https://example.com/photo.jpg",
+              alt: "Photo",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const paragraph = result.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe("https://example.com/photo.jpg");
+  });
+
+  it("絶対 URL (http://) はそのまま保持する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "http://example.com/photo.jpg",
+              alt: "Photo",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const paragraph = result.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe("http://example.com/photo.jpg");
+  });
+
+  it("image ノードがない場合はツリーをそのまま返す", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "Hello world",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    expect(result).toEqual(tree);
+  });
+
+  it("ネストされた image ノードも走査して変換する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "blockquote",
+          children: [
+            {
+              type: "paragraph",
+              children: [
+                {
+                  type: "image",
+                  url: "nested/image.png",
+                  alt: "Nested",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const blockquote = result.children[0];
+    if (blockquote.type !== "blockquote") throw new Error("unexpected");
+    const paragraph = blockquote.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe("/api/v1/notes/my-article/assets/nested/image.png");
+  });
+
+  it("元のツリーを変更せず、新しいツリーを返す", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "photo.png",
+              alt: "Photo",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    expect(result).not.toBe(tree);
+
+    const originalParagraph = tree.children[0];
+    if (originalParagraph.type !== "paragraph") throw new Error("unexpected");
+    const originalImage = originalParagraph.children[0];
+    if (originalImage.type !== "image") throw new Error("unexpected");
+    expect(originalImage.url).toBe("photo.png");
+  });
+
+  it("複数の image ノードを含むツリーですべて変換する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "first.png",
+              alt: "First",
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "https://external.com/second.png",
+              alt: "Second",
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "third.jpg",
+              alt: "Third",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const getImageUrl = (index: number): string => {
+      const paragraph = result.children[index];
+      if (paragraph.type !== "paragraph") throw new Error("unexpected");
+      const image = paragraph.children[0];
+      if (image.type !== "image") throw new Error("unexpected");
+      return image.url;
+    };
+
+    expect(getImageUrl(0)).toBe("/api/v1/notes/my-article/assets/first.png");
+    expect(getImageUrl(1)).toBe("https://external.com/second.png");
+    expect(getImageUrl(2)).toBe("/api/v1/notes/my-article/assets/third.jpg");
+  });
+});

--- a/app/backend/domain/note/resolve-image-urls.ts
+++ b/app/backend/domain/note/resolve-image-urls.ts
@@ -5,8 +5,11 @@ import type { Image, Root } from "mdast";
 const isAbsoluteUrl = (url: string): boolean =>
   url.startsWith("http://") || url.startsWith("https://");
 
+const normalizePath = (path: string): string =>
+  path.startsWith("./") ? path.slice(2) : path;
+
 const toAssetApiUrl = (slug: NoteSlug, relativePath: string): string =>
-  `/api/v1/notes/${slug.value}/assets/${relativePath}`;
+  `/api/v1/notes/${slug.value}/assets/${normalizePath(relativePath)}`;
 
 export function resolveImageUrls(tree: Root, slug: NoteSlug): Root {
   const cloned = structuredClone(tree);

--- a/app/backend/domain/note/resolve-image-urls.ts
+++ b/app/backend/domain/note/resolve-image-urls.ts
@@ -1,0 +1,21 @@
+import { visit } from "unist-util-visit";
+import type { NoteSlug } from "./note-slug.vo";
+import type { Image, Root } from "mdast";
+
+const isAbsoluteUrl = (url: string): boolean =>
+  url.startsWith("http://") || url.startsWith("https://");
+
+const toAssetApiUrl = (slug: NoteSlug, relativePath: string): string =>
+  `/api/v1/notes/${slug.value}/assets/${relativePath}`;
+
+export function resolveImageUrls(tree: Root, slug: NoteSlug): Root {
+  const cloned = structuredClone(tree);
+
+  visit(cloned, "image", (node: Image) => {
+    if (!isAbsoluteUrl(node.url)) {
+      node.url = toAssetApiUrl(slug, node.url);
+    }
+  });
+
+  return cloned;
+}

--- a/app/backend/domain/note/usecases/get-note-detail.usecase.test.ts
+++ b/app/backend/domain/note/usecases/get-note-detail.usecase.test.ts
@@ -1,0 +1,154 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ETag } from "../../shared/etag.vo";
+import { MarkdownNotFoundError, NoteNotFoundError } from "../errors";
+import { ImageUrl } from "../image-url.vo";
+import { NoteSlug } from "../note-slug.vo";
+import { NoteTitle } from "../note-title.vo";
+import { Note } from "../note.entity";
+import { GetNoteDetailUseCase } from "./get-note-detail.usecase";
+import type { IPersisted } from "../../shared/persisted.interface";
+import type { IMarkdownStorage } from "../markdown-storage.interface";
+import type { INoteQueryRepository } from "../note.query-repository.interface";
+
+const slug = NoteSlug.create("my-article");
+
+const createPersistedNote = (): Note<IPersisted> =>
+  Note.reconstruct({
+    id: "note-123",
+    title: NoteTitle.create("My Article Title"),
+    slug,
+    etag: ETag.create("etag-abc"),
+    imageUrl: ImageUrl.create("https://example.com/cover.png"),
+    publishedOn: Temporal.PlainDate.from("2026-02-15"),
+    lastModifiedOn: Temporal.PlainDate.from("2026-02-18"),
+    createdAt: Temporal.Instant.from("2026-01-01T00:00:00Z"),
+    updatedAt: Temporal.Instant.from("2026-01-01T00:00:00Z"),
+  });
+
+const createMarkdownStream = (content: string): ReadableStream => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller): void {
+      controller.enqueue(encoder.encode(content));
+      controller.close();
+    },
+  });
+};
+
+describe("GetNoteDetailUseCase", () => {
+  let mockQueryRepository: INoteQueryRepository;
+  let mockMarkdownStorage: IMarkdownStorage;
+  let mockFindBySlug: ReturnType<typeof vi.fn>;
+  let mockStorageGet: ReturnType<typeof vi.fn>;
+  let useCase: GetNoteDetailUseCase;
+
+  beforeEach(() => {
+    mockFindBySlug = vi.fn();
+    mockStorageGet = vi.fn();
+    mockQueryRepository = {
+      findAll: vi.fn(),
+      findBySlug: mockFindBySlug,
+      findPaginated: vi.fn(),
+    } as unknown as INoteQueryRepository;
+    mockMarkdownStorage = {
+      get: mockStorageGet,
+      list: vi.fn(),
+    } as unknown as IMarkdownStorage;
+    useCase = new GetNoteDetailUseCase(
+      mockQueryRepository,
+      mockMarkdownStorage,
+    );
+  });
+
+  it("正常系: メタデータと mdast コンテンツを含む結果を返す", async () => {
+    const note = createPersistedNote();
+    mockFindBySlug.mockResolvedValue(note);
+
+    const markdownContent = `---
+title: "My Article Title"
+imageUrl: "https://example.com/cover.png"
+publishedOn: "2026-02-15"
+lastModifiedOn: "2026-02-18"
+---
+
+# Introduction
+
+Hello world.
+`;
+    mockStorageGet.mockResolvedValue({
+      body: createMarkdownStream(markdownContent),
+      etag: ETag.create("etag-abc"),
+    });
+
+    const result = await useCase.execute(slug);
+
+    expect(result.id).toBe("note-123");
+    expect(result.title).toBe("My Article Title");
+    expect(result.slug).toBe("my-article");
+    expect(result.imageUrl).toBe("https://example.com/cover.png");
+    expect(result.publishedOn).toBe("2026-02-15");
+    expect(result.lastModifiedOn).toBe("2026-02-18");
+    expect(result.content.type).toBe("root");
+    expect(result.content.children.length).toBeGreaterThan(0);
+  });
+
+  it("正常系: frontmatter が mdast content から除去されている", async () => {
+    const note = createPersistedNote();
+    mockFindBySlug.mockResolvedValue(note);
+
+    const markdownContent = `---
+title: "My Article Title"
+---
+
+# Hello
+`;
+    mockStorageGet.mockResolvedValue({
+      body: createMarkdownStream(markdownContent),
+      etag: ETag.create("etag-abc"),
+    });
+
+    const result = await useCase.execute(slug);
+
+    const hasYaml = result.content.children.some(
+      (child) => child.type === "yaml",
+    );
+    expect(hasYaml).toBe(false);
+  });
+
+  it("正常系: 日付フィールドが ISO 8601 形式 (YYYY-MM-DD) で返る", async () => {
+    const note = createPersistedNote();
+    mockFindBySlug.mockResolvedValue(note);
+    mockStorageGet.mockResolvedValue({
+      body: createMarkdownStream("# Hello"),
+      etag: ETag.create("etag-abc"),
+    });
+
+    const result = await useCase.execute(slug);
+
+    expect(result.publishedOn).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.lastModifiedOn).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("記事が DB に存在しない場合は NoteNotFoundError をスローする", async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    mockFindBySlug.mockResolvedValue(undefined);
+
+    await expect(useCase.execute(slug)).rejects.toThrow(NoteNotFoundError);
+  });
+
+  it("Markdown がストレージに存在しない場合は MarkdownNotFoundError をスローする", async () => {
+    const note = createPersistedNote();
+    mockFindBySlug.mockResolvedValue(note);
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    mockStorageGet.mockResolvedValue(undefined);
+
+    await expect(useCase.execute(slug)).rejects.toThrow(MarkdownNotFoundError);
+  });
+
+  it("リポジトリやストレージのエラーはそのままスローする", async () => {
+    mockFindBySlug.mockRejectedValue(new Error("DB connection failed"));
+
+    await expect(useCase.execute(slug)).rejects.toThrow("DB connection failed");
+  });
+});

--- a/app/backend/domain/note/usecases/get-note-detail.usecase.ts
+++ b/app/backend/domain/note/usecases/get-note-detail.usecase.ts
@@ -1,0 +1,38 @@
+import { MarkdownNotFoundError, NoteNotFoundError } from "../errors";
+import { markdownToMdast } from "../markdown-to-mdast";
+import type { IMarkdownStorage } from "../markdown-storage.interface";
+import type { NoteSlug } from "../note-slug.vo";
+import type { INoteQueryRepository } from "../note.query-repository.interface";
+import type { NoteDetailResponse } from "~/lib/types/notes";
+
+export class GetNoteDetailUseCase {
+  constructor(
+    private readonly queryRepository: INoteQueryRepository,
+    private readonly markdownStorage: IMarkdownStorage,
+  ) {}
+
+  async execute(slug: NoteSlug): Promise<NoteDetailResponse> {
+    const note = await this.queryRepository.findBySlug(slug);
+    if (!note) {
+      throw new NoteNotFoundError(slug.value);
+    }
+
+    const markdownContent = await this.markdownStorage.get(slug);
+    if (!markdownContent) {
+      throw new MarkdownNotFoundError(slug.value);
+    }
+
+    const text = await new Response(markdownContent.body).text();
+    const content = markdownToMdast(text, slug);
+
+    return {
+      id: note.id,
+      title: note.title.toJSON(),
+      slug: note.slug.toJSON(),
+      imageUrl: note.imageUrl.toJSON(),
+      publishedOn: note.publishedOn.toString(),
+      lastModifiedOn: note.lastModifiedOn.toString(),
+      content,
+    };
+  }
+}

--- a/app/backend/handlers/api/v1/notes/index.test.ts
+++ b/app/backend/handlers/api/v1/notes/index.test.ts
@@ -2,16 +2,20 @@ import { Temporal } from "@js-temporal/polyfill";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import {
+  MarkdownNotFoundError,
   NoteMetadataValidationError,
+  NoteNotFoundError,
   NoteParseError,
 } from "../../../../domain/note/errors";
 import { ImageUrl } from "../../../../domain/note/image-url.vo";
 import { NoteSlug } from "../../../../domain/note/note-slug.vo";
 import { NoteTitle } from "../../../../domain/note/note-title.vo";
 import { Note } from "../../../../domain/note/note.entity";
+import { ContentType } from "../../../../domain/shared/content-type.vo";
 import { ETag } from "../../../../domain/shared/etag.vo";
 import { notesApp } from ".";
 import type { IPersisted } from "../../../../domain/shared/persisted.interface";
+import type { Root } from "mdast";
 
 const createPersistedNote = (
   id: string,
@@ -31,6 +35,8 @@ const createPersistedNote = (
   });
 
 const mockFindPaginated = vi.fn();
+const mockUseCaseExecute = vi.fn();
+const mockAssetStorageGet = vi.fn();
 
 // Mock drizzle
 vi.mock("drizzle-orm/d1", () => ({
@@ -78,6 +84,25 @@ vi.mock("../../../../infra/r2/note/markdown.storage", () => ({
   MarkdownStorage: vi.fn(function (this: unknown) {
     return {
       get: vi.fn(),
+      list: vi.fn(),
+    };
+  }),
+}));
+
+// Mock GetNoteDetailUseCase
+vi.mock("../../../../domain/note/usecases/get-note-detail.usecase", () => ({
+  GetNoteDetailUseCase: vi.fn(function (this: unknown) {
+    return {
+      execute: mockUseCaseExecute,
+    };
+  }),
+}));
+
+// Mock AssetStorage
+vi.mock("../../../../infra/r2/note/asset.storage", () => ({
+  AssetStorage: vi.fn(function (this: unknown) {
+    return {
+      get: mockAssetStorageGet,
       list: vi.fn(),
     };
   }),
@@ -473,6 +498,281 @@ describe("Notes API Handler", () => {
 
         consoleErrorSpy.mockRestore();
       });
+    });
+  });
+
+  describe("GET /api/v1/notes/:noteSlug (記事詳細)", () => {
+    const mockMdastRoot: Root = {
+      type: "root",
+      children: [
+        {
+          type: "heading",
+          depth: 1,
+          children: [{ type: "text", value: "Hello" }],
+        },
+      ],
+    };
+
+    it("正常レスポンスを 200 JSON で返す", async () => {
+      mockUseCaseExecute.mockResolvedValue({
+        id: "note-123",
+        title: "My Article",
+        slug: "my-article",
+        imageUrl: "https://example.com/cover.png",
+        publishedOn: "2026-02-15",
+        lastModifiedOn: "2026-02-18",
+        content: mockMdastRoot,
+      });
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("application/json");
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        id: "note-123",
+        title: "My Article",
+        slug: "my-article",
+        imageUrl: "https://example.com/cover.png",
+        publishedOn: "2026-02-15",
+        lastModifiedOn: "2026-02-18",
+        content: { type: "root" },
+      });
+    });
+
+    it("不正な slug 形式の場合 400 ProblemDetails を返す", async () => {
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/INVALID SLUG!",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Bad Request",
+        status: 400,
+      });
+    });
+
+    it("記事が DB に存在しない場合 404 ProblemDetails を返す", async () => {
+      mockUseCaseExecute.mockRejectedValue(
+        new NoteNotFoundError("nonexistent"),
+      );
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/nonexistent",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Not Found",
+        status: 404,
+      });
+    });
+
+    it("Markdown がストレージに存在しない場合 404 ProblemDetails を返す", async () => {
+      mockUseCaseExecute.mockRejectedValue(
+        new MarkdownNotFoundError("my-article"),
+      );
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Not Found",
+        status: 404,
+      });
+    });
+
+    it("内部エラー時に 500 ProblemDetails を返す", async () => {
+      mockUseCaseExecute.mockRejectedValue(new Error("DB connection failed"));
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(vi.fn());
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Internal Server Error",
+        status: 500,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("内部エラー時に console.error でログ出力する", async () => {
+      mockUseCaseExecute.mockRejectedValue(new Error("Unexpected error"));
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(vi.fn());
+
+      const app = createApp();
+      await app.request("/api/v1/notes/my-article", { method: "GET" }, testEnv);
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("GET /api/v1/notes/:noteSlug/assets/* (アセット配信)", () => {
+    it("アセットをバイナリストリームで返す", async () => {
+      const binaryData = new Uint8Array([137, 80, 78, 71]);
+      const stream = new ReadableStream({
+        start(controller): void {
+          controller.enqueue(binaryData);
+          controller.close();
+        },
+      });
+
+      mockAssetStorageGet.mockResolvedValue({
+        body: stream,
+        contentType: ContentType.create("image/png"),
+        size: 4,
+        etag: ETag.create("etag-asset-1"),
+      });
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article/assets/images/diagram.png",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("image/png");
+      expect(res.headers.get("ETag")).toBe("etag-asset-1");
+
+      const buffer = await res.arrayBuffer();
+      expect(new Uint8Array(buffer)).toEqual(binaryData);
+    });
+
+    it("不正な slug 形式の場合 400 ProblemDetails を返す", async () => {
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/INVALID SLUG!/assets/image.png",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Bad Request",
+        status: 400,
+      });
+    });
+
+    it("アセットが見つからない場合 404 ProblemDetails を返す", async () => {
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      mockAssetStorageGet.mockResolvedValue(undefined);
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article/assets/nonexistent.png",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Not Found",
+        status: 404,
+      });
+    });
+
+    it("内部エラー時に 500 ProblemDetails を返す", async () => {
+      mockAssetStorageGet.mockRejectedValue(new Error("R2 access failed"));
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(vi.fn());
+
+      const app = createApp();
+      const res = await app.request(
+        "/api/v1/notes/my-article/assets/image.png",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Content-Type")).toContain(
+        "application/problem+json",
+      );
+      const json = await parseJson(res);
+      expect(json).toMatchObject({
+        type: "about:blank",
+        title: "Internal Server Error",
+        status: 500,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("内部エラー時に console.error でログ出力する", async () => {
+      mockAssetStorageGet.mockRejectedValue(new Error("R2 error"));
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(vi.fn());
+
+      const app = createApp();
+      await app.request(
+        "/api/v1/notes/my-article/assets/image.png",
+        { method: "GET" },
+        testEnv,
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/app/backend/handlers/api/v1/notes/index.ts
+++ b/app/backend/handlers/api/v1/notes/index.ts
@@ -129,7 +129,8 @@ export const notesApp = new Hono<{ Bindings: Env }>()
         error instanceof NoteParseError ||
         error instanceof NoteMetadataValidationError ||
         error instanceof InvalidNoteTitleError ||
-        error instanceof InvalidImageUrlError
+        error instanceof InvalidImageUrlError ||
+        error instanceof InvalidNoteSlugError
       ) {
         const problemDetails: ProblemDetails = {
           type: "about:blank",

--- a/app/backend/handlers/api/v1/notes/index.ts
+++ b/app/backend/handlers/api/v1/notes/index.ts
@@ -2,17 +2,24 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import {
   InvalidImageUrlError,
+  InvalidNoteSlugError,
   InvalidNoteTitleError,
+  MarkdownNotFoundError,
   NoteMetadataValidationError,
+  NoteNotFoundError,
   NoteParseError,
 } from "../../../../domain/note/errors";
+import { NoteSlug } from "../../../../domain/note/note-slug.vo";
+import { GetNoteDetailUseCase } from "../../../../domain/note/usecases/get-note-detail.usecase";
 import { ListNotesUseCase } from "../../../../domain/note/usecases/list-notes.usecase";
+import { ObjectKey } from "../../../../domain/shared/object-key.vo";
 import {
   PaginationParams,
   PaginationValidationError,
 } from "../../../../domain/shared/pagination/pagination-params.vo";
 import { NoteCommandRepository } from "../../../../infra/d1/note/note.command-repository";
 import { NoteQueryRepository } from "../../../../infra/d1/note/note.query-repository";
+import { AssetStorage } from "../../../../infra/r2/note/asset.storage";
 import { MarkdownStorage } from "../../../../infra/r2/note/markdown.storage";
 import { NotesRefreshService } from "../../../../services/notes-refresh.service";
 import type { Note } from "../../../../domain/note/note.entity";
@@ -141,6 +148,149 @@ export const notesApp = new Hono<{ Bindings: Env }>()
 
       const detail =
         error instanceof Error ? error.message : "Failed to refresh notes";
+
+      const problemDetails: ProblemDetails = {
+        type: "about:blank",
+        title: "Internal Server Error",
+        status: 500,
+        detail,
+      };
+
+      return Response.json(problemDetails, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+  })
+  .get("/:noteSlug/assets/*", async (c): Promise<Response> => {
+    try {
+      const noteSlugParam = c.req.param("noteSlug");
+
+      let slug: NoteSlug;
+      try {
+        slug = NoteSlug.create(noteSlugParam);
+      } catch (error) {
+        if (error instanceof InvalidNoteSlugError) {
+          const problemDetails: ProblemDetails = {
+            type: "about:blank",
+            title: "Bad Request",
+            status: 400,
+            detail: error.message,
+          };
+
+          return Response.json(problemDetails, {
+            status: 400,
+            headers: { "Content-Type": "application/problem+json" },
+          });
+        }
+        throw error;
+      }
+
+      const assetPath = c.req.path.replace(
+        `/api/v1/notes/${noteSlugParam}/assets/`,
+        "",
+      );
+      const objectKey = ObjectKey.create(`${slug.value}/${assetPath}`);
+      const assetStorage = new AssetStorage(c.env.R2);
+      const asset = await assetStorage.get(objectKey);
+
+      if (!asset) {
+        const problemDetails: ProblemDetails = {
+          type: "about:blank",
+          title: "Not Found",
+          status: 404,
+          detail: `Asset not found: ${assetPath}`,
+        };
+
+        return Response.json(problemDetails, {
+          status: 404,
+          headers: { "Content-Type": "application/problem+json" },
+        });
+      }
+
+      return new Response(asset.body, {
+        status: 200,
+        headers: {
+          "Content-Type": asset.contentType.value,
+          ETag: asset.etag.value,
+        },
+      });
+    } catch (error) {
+      console.error("Asset delivery error:", error);
+
+      const detail =
+        error instanceof Error ? error.message : "Failed to deliver asset";
+
+      const problemDetails: ProblemDetails = {
+        type: "about:blank",
+        title: "Internal Server Error",
+        status: 500,
+        detail,
+      };
+
+      return Response.json(problemDetails, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+  })
+  .get("/:noteSlug", async (c): Promise<Response> => {
+    try {
+      const noteSlugParam = c.req.param("noteSlug");
+
+      let slug: NoteSlug;
+      try {
+        slug = NoteSlug.create(noteSlugParam);
+      } catch (error) {
+        if (error instanceof InvalidNoteSlugError) {
+          const problemDetails: ProblemDetails = {
+            type: "about:blank",
+            title: "Bad Request",
+            status: 400,
+            detail: error.message,
+          };
+
+          return Response.json(problemDetails, {
+            status: 400,
+            headers: { "Content-Type": "application/problem+json" },
+          });
+        }
+        throw error;
+      }
+
+      const db = drizzle(c.env.D1);
+      const queryRepository = new NoteQueryRepository(db);
+      const markdownStorage = new MarkdownStorage(c.env.R2);
+      const useCase = new GetNoteDetailUseCase(
+        queryRepository,
+        markdownStorage,
+      );
+
+      const result = await useCase.execute(slug);
+
+      return c.json(result);
+    } catch (error) {
+      if (
+        error instanceof NoteNotFoundError ||
+        error instanceof MarkdownNotFoundError
+      ) {
+        const problemDetails: ProblemDetails = {
+          type: "about:blank",
+          title: "Not Found",
+          status: 404,
+          detail: error.message,
+        };
+
+        return Response.json(problemDetails, {
+          status: 404,
+          headers: { "Content-Type": "application/problem+json" },
+        });
+      }
+
+      console.error("Note detail error:", error);
+
+      const detail =
+        error instanceof Error ? error.message : "Failed to get note detail";
 
       const problemDetails: ProblemDetails = {
         type: "about:blank",

--- a/app/backend/infra/r2/note/markdown.storage.test.ts
+++ b/app/backend/infra/r2/note/markdown.storage.test.ts
@@ -89,6 +89,26 @@ describe("MarkdownStorage", () => {
       expect(result[0].slug).toEqual(NoteSlug.create("article"));
     });
 
+    it("should skip markdown files in subdirectories (slug containing slash)", async () => {
+      const mockR2Objects: R2Objects = {
+        objects: [
+          createMockR2Object("notes/valid-article.md", "etag1"),
+          createMockR2Object("notes/subdir/nested.md", "etag2"),
+          createMockR2Object("notes/deep/path/file.md", "etag3"),
+        ],
+        truncated: false,
+        delimitedPrefixes: [],
+      };
+
+      vi.mocked(mockR2Bucket.list).mockResolvedValue(mockR2Objects);
+
+      const storage = new MarkdownStorage(mockR2Bucket);
+      const result = await storage.list();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toEqual(NoteSlug.create("valid-article"));
+    });
+
     it("should return empty array when no markdown files exist", async () => {
       const mockR2Objects: R2Objects = {
         objects: [],

--- a/app/backend/infra/r2/note/markdown.storage.ts
+++ b/app/backend/infra/r2/note/markdown.storage.ts
@@ -33,7 +33,9 @@ export class MarkdownStorage implements IMarkdownStorage {
       .filter((obj) => obj.key.endsWith(MD_EXTENSION))
       .filter(
         (obj) =>
-          !obj.key.slice(NOTES_PREFIX.length, -MD_EXTENSION.length).includes("/"),
+          !obj.key
+            .slice(NOTES_PREFIX.length, -MD_EXTENSION.length)
+            .includes("/"),
       )
       .map((obj) => ({
         slug: NoteSlug.create(

--- a/app/backend/infra/r2/note/markdown.storage.ts
+++ b/app/backend/infra/r2/note/markdown.storage.ts
@@ -31,6 +31,10 @@ export class MarkdownStorage implements IMarkdownStorage {
 
     return r2Objects.objects
       .filter((obj) => obj.key.endsWith(MD_EXTENSION))
+      .filter(
+        (obj) =>
+          !obj.key.slice(NOTES_PREFIX.length, -MD_EXTENSION.length).includes("/"),
+      )
       .map((obj) => ({
         slug: NoteSlug.create(
           obj.key.slice(NOTES_PREFIX.length, -MD_EXTENSION.length),

--- a/app/lib/types/notes.ts
+++ b/app/lib/types/notes.ts
@@ -1,5 +1,17 @@
+import type { Root } from "mdast";
+
 export type NotesRefreshResponse = {
   readonly added: number;
   readonly updated: number;
   readonly deleted: number;
+};
+
+export type NoteDetailResponse = {
+  readonly id: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly imageUrl: string;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+  readonly content: Root;
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
+    "unist-util-visit": "5",
     "vfile": "^6.0.3",
     "vfile-matter": "^5.0.1"
   },
@@ -56,6 +57,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",
     "@types/eslint-plugin-security": "^3.0.1",
+    "@types/mdast": "4",
     "@types/node": "^22",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: '5'
+        version: 5.1.0
       vfile:
         specifier: ^6.0.3
         version: 6.0.3
@@ -78,6 +81,9 @@ importers:
       '@types/eslint-plugin-security':
         specifier: ^3.0.1
         version: 3.0.1
+      '@types/mdast':
+        specifier: '4'
+        version: 4.0.4
       '@types/node':
         specifier: ^22
         version: 22.19.1


### PR DESCRIPTION
## 概要

記事詳細 API (`GET /api/v1/notes/{noteSlug}`) とアセット配信 API (`GET /api/v1/notes/{noteSlug}/assets/*`) を実装。Markdown 本文を mdast (Markdown Abstract Syntax Tree) 形式で返し、相対画像パスをアセット配信 API の URL に解決する。

## 変更内容

- [x] ドメイン層: Markdown → mdast 変換ロジック (`markdown-to-mdast.ts`, `resolve-image-urls.ts`)
- [x] ドメイン層: `GetNoteDetailUseCase` (メタデータ + mdast 取得)
- [x] ドメイン層: `NoteNotFoundError`, `MarkdownNotFoundError` エラークラス追加
- [x] ハンドラ層: `GET /api/v1/notes/:noteSlug` エンドポイント
- [x] ハンドラ層: `GET /api/v1/notes/:noteSlug/assets/*` アセット配信エンドポイント
- [x] エラーハンドリング: 404/400/422/500 の RFC 9457 準拠レスポンス
- [x] `ImageUrl` VO で絶対パスも受け入れるようバリデーション拡張
- [x] frontmatter の `imageUrl` で相対パスをアセット API URL に解決
- [x] `MarkdownStorage.list()` でサブディレクトリの .md をフィルタ
- [x] `/refresh` の 422 マッピングに `InvalidNoteSlugError` を追加
- [x] 相対画像パスの `./` プレフィックス正規化
- [x] 全レイヤのユニットテスト (268 テスト全パス)
- [x] Kiro spec-driven development (要件定義 → 設計 → タスク → 実装 → 検証)

close #32