### PR TITLE
fix: #32 PR #43 レビューコメント対応

### DIFF
--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -47,6 +47,12 @@ describe("ImageUrl Value Object", () => {
         InvalidImageUrlError,
       );
     });
+
+    it("should throw an error for a protocol-relative URL", () => {
+      expect(() => ImageUrl.create("//example.com/image.png")).toThrow(
+        InvalidImageUrlError,
+      );
+    });
   });
 
   describe("equals()", () => {

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -23,7 +23,7 @@ export class ImageUrl implements IValueObject<ImageUrl> {
     if (value.length === 0) {
       return false;
     }
-    if (value.startsWith("/")) {
+    if (value.startsWith("/") && !value.startsWith("//")) {
       return true;
     }
     try {

--- a/app/backend/domain/note/note-content.parser.test.ts
+++ b/app/backend/domain/note/note-content.parser.test.ts
@@ -76,6 +76,24 @@ lastModifiedOn: "2025-02-01"
     ).toBe(true);
   });
 
+  it("'/' 始まりの絶対パスの imageUrl はそのまま保持する", () => {
+    const content = `---
+title: "テスト記事"
+imageUrl: "/images/cover.png"
+publishedOn: "2025-01-15"
+lastModifiedOn: "2025-02-01"
+---
+
+# 本文
+`;
+
+    const metadata = parseNoteContent(content, slug);
+
+    expect(metadata.imageUrl.equals(ImageUrl.create("/images/cover.png"))).toBe(
+      true,
+    );
+  });
+
   it("絶対 URL の imageUrl はそのまま保持する", () => {
     const content = `---
 title: "テスト記事"

--- a/app/backend/domain/note/note-content.parser.ts
+++ b/app/backend/domain/note/note-content.parser.ts
@@ -7,7 +7,9 @@ import { NoteTitle } from "./note-title.vo";
 import type { NoteSlug } from "./note-slug.vo";
 
 const isAbsoluteUrl = (url: string): boolean =>
-  url.startsWith("http://") || url.startsWith("https://");
+  url.startsWith("/") ||
+  url.startsWith("http://") ||
+  url.startsWith("https://");
 
 const resolveImageUrl = (url: string, slug: NoteSlug): string => {
   if (isAbsoluteUrl(url)) return url;

--- a/app/backend/domain/note/resolve-image-urls.test.ts
+++ b/app/backend/domain/note/resolve-image-urls.test.ts
@@ -199,6 +199,33 @@ describe("resolveImageUrls", () => {
     expect(image.url).toBe("/api/v1/notes/my-article/assets/hero.png");
   });
 
+  it("'/' 始まりの絶対パスはそのまま保持する", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "image",
+              url: "/images/foo.png",
+              alt: "Absolute path",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveImageUrls(tree, slug);
+
+    const paragraph = result.children[0];
+    if (paragraph.type !== "paragraph") throw new Error("unexpected");
+    const image = paragraph.children[0];
+    if (image.type !== "image") throw new Error("unexpected");
+
+    expect(image.url).toBe("/images/foo.png");
+  });
+
   it("複数の image ノードを含むツリーですべて変換する", () => {
     const tree: Root = {
       type: "root",

--- a/app/backend/domain/note/resolve-image-urls.ts
+++ b/app/backend/domain/note/resolve-image-urls.ts
@@ -3,7 +3,9 @@ import type { NoteSlug } from "./note-slug.vo";
 import type { Image, Root } from "mdast";
 
 const isAbsoluteUrl = (url: string): boolean =>
-  url.startsWith("http://") || url.startsWith("https://");
+  url.startsWith("/") ||
+  url.startsWith("http://") ||
+  url.startsWith("https://");
 
 const normalizePath = (path: string): string =>
   path.startsWith("./") ? path.slice(2) : path;

--- a/app/backend/domain/note/usecases/get-note-detail.usecase.ts
+++ b/app/backend/domain/note/usecases/get-note-detail.usecase.ts
@@ -3,7 +3,17 @@ import { markdownToMdast } from "../markdown-to-mdast";
 import type { IMarkdownStorage } from "../markdown-storage.interface";
 import type { NoteSlug } from "../note-slug.vo";
 import type { INoteQueryRepository } from "../note.query-repository.interface";
-import type { NoteDetailResponse } from "~/lib/types/notes";
+import type { Root } from "mdast";
+
+export type NoteDetailDto = {
+  readonly id: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly imageUrl: string;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+  readonly content: Root;
+};
 
 export class GetNoteDetailUseCase {
   constructor(
@@ -11,7 +21,7 @@ export class GetNoteDetailUseCase {
     private readonly markdownStorage: IMarkdownStorage,
   ) {}
 
-  async execute(slug: NoteSlug): Promise<NoteDetailResponse> {
+  async execute(slug: NoteSlug): Promise<NoteDetailDto> {
     const note = await this.queryRepository.findBySlug(slug);
     if (!note) {
       throw new NoteNotFoundError(slug.value);

--- a/app/backend/handlers/api/v1/notes/index.ts
+++ b/app/backend/handlers/api/v1/notes/index.ts
@@ -163,7 +163,7 @@ export const notesApp = new Hono<{ Bindings: Env }>()
       });
     }
   })
-  .get("/:noteSlug/assets/*", async (c): Promise<Response> => {
+  .get("/:noteSlug/assets/:assetPath{.+}", async (c): Promise<Response> => {
     try {
       const noteSlugParam = c.req.param("noteSlug");
 
@@ -187,10 +187,7 @@ export const notesApp = new Hono<{ Bindings: Env }>()
         throw error;
       }
 
-      const assetPath = c.req.path.replace(
-        `/api/v1/notes/${noteSlugParam}/assets/`,
-        "",
-      );
+      const assetPath = c.req.param("assetPath");
       const objectKey = ObjectKey.create(`${slug.value}/${assetPath}`);
       const assetStorage = new AssetStorage(c.env.R2);
       const asset = await assetStorage.get(objectKey);

--- a/app/lib/types/notes.ts
+++ b/app/lib/types/notes.ts
@@ -1,17 +1,7 @@
-import type { Root } from "mdast";
+export type { NoteDetailDto as NoteDetailResponse } from "~/backend/domain/note/usecases/get-note-detail.usecase";
 
 export type NotesRefreshResponse = {
   readonly added: number;
   readonly updated: number;
   readonly deleted: number;
-};
-
-export type NoteDetailResponse = {
-  readonly id: string;
-  readonly title: string;
-  readonly slug: string;
-  readonly imageUrl: string;
-  readonly publishedOn: string;
-  readonly lastModifiedOn: string;
-  readonly content: Root;
 };


### PR DESCRIPTION
## 概要

PR #43 にて Copilot から指摘された5件のレビューコメントに対する修正。

## 変更内容

- [x] `GetNoteDetailUseCase` のレイヤ分離: `NoteDetailResponse` (HTTP 層型) → `NoteDetailDto` (ドメイン層型) に変更し、DIP 違反を解消
- [x] `resolve-image-urls`: `/` 始まりの絶対パスを変換対象から除外 (`/images/foo.png` がダブルスラッシュにならないよう修正)
- [x] `note-content.parser`: frontmatter の `imageUrl` が `/` 始まりの絶対パスの場合そのまま保持
- [x] `ImageUrl` VO: `//example.com/image.png` のようなプロトコル相対 URL を不正値として拒否
- [x] アセットパス抽出: `c.req.path.replace(...)` → Hono の名前付きパラメータ `:assetPath{.+}` に変更し、フラジャイルな文字列操作を排除

close #32