### PR TITLE
fix: Docker コンテナでたまに名前解決できなくなる問題を修正

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -12,6 +12,9 @@ services:
       - ./fish/functions/git.fish:/home/vscode/.config/fish/functions/git.fish
       # Chrome sandbox needs access to /dev/shm
       - /dev/shm:/dev/shm
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     command: sleep infinity
     user: vscode
     # Chrome sandbox security settings


### PR DESCRIPTION
## 概要

スリープ復帰後などに devcontainer 内で DNS 解決が断続的に失敗する問題を修正した。

## 変更内容

- [ ] `.devcontainer/compose.yaml` に `dns` オプションを追加し、Google Public DNS（8.8.8.8 / 8.8.4.4）を明示指定

close #54