### PR TITLE
feat(domain): ノートのドメインモデルを定義する

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -1,7 +1,7 @@
 # 環境構成
 
-| 環境        | トリガー          | DB                                         |
-| ----------- | ----------------- | ------------------------------------------ |
+| 環境        | トリガー          | DB                          |
+| ----------- | ----------------- | --------------------------- |
 | development | ローカル          | yantene-development (local) |
 | staging     | PR / push to main | yantene-staging             |
 | production  | GitHub Release    | yantene-production          |

--- a/.claude/rules/product.md
+++ b/.claude/rules/product.md
@@ -51,7 +51,7 @@ NoteTitle / ImageUrl 等の VO に変換する。
 ```yaml
 ---
 title: 記事タイトル
-imageUrl: ./cover.png       # 相対パス → アセット API URL に解決される
+imageUrl: ./cover.png # 相対パス → アセット API URL に解決される
 publishedOn: 2026-01-15
 lastModifiedOn: 2026-01-20
 ---

--- a/app/backend/domain/note/errors.ts
+++ b/app/backend/domain/note/errors.ts
@@ -1,0 +1,6 @@
+export class NoteNotFoundError extends Error {
+  readonly name = "NoteNotFoundError";
+  constructor(slug: string) {
+    super(`Note not found: ${slug}`);
+  }
+}

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+
+describe("ImageUrl", () => {
+  it("accepts a root-relative asset API path", () => {
+    const url = "/api/v1/notes/my-note/assets/cover.png";
+    expect(ImageUrl.create(url).toString()).toBe(url);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(ImageUrl.create("  /a/b.png  ").toString()).toBe("/a/b.png");
+  });
+
+  it("rejects unresolved relative paths", () => {
+    expect(() => ImageUrl.create("./cover.png")).toThrow(InvalidImageUrlError);
+    expect(() => ImageUrl.create("cover.png")).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects absolute URLs, including raw Artifacts URLs", () => {
+    // 絶対 URL は Artifacts の直接 URL 露出につながり、CSP (img-src 'self') でも
+    // 表示できないため弾く。
+    expect(() => ImageUrl.create("https://example.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() =>
+      ImageUrl.create("https://artifacts.example/raw/notes/x/cover.png"),
+    ).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects protocol-relative and non-http schemes", () => {
+    expect(() => ImageUrl.create("//evil.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("javascript:alert(1)")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("data:image/png;base64,AAAA")).toThrow(
+      InvalidImageUrlError,
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => ImageUrl.create(" ".repeat(3))).toThrow(InvalidImageUrlError);
+  });
+
+  it("compares by value with equals", () => {
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/a.png"))).toBe(
+      true,
+    );
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/b.png"))).toBe(
+      false,
+    );
+  });
+});

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -1,0 +1,48 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// ノートのカバー画像 URL。フロントマターの相対パス (`./cover.png`) は
+// アセット API URL (ルート相対 `/api/v1/notes/<slug>/assets/...`) に解決してから
+// VO 化する前提で、ここでは解決済みの「ルート相対パス」だけを受け入れる。
+//
+// 絶対 URL は弾く。これは 2 つの規約を同時に満たすため:
+//   - Artifacts の直接 URL を露出させない (product 規約)。絶対 URL を許すと
+//     未解決の生 Artifacts URL がそのまま通り得る。
+//   - 画像はアセット API (self) 経由で配信する。CSP の img-src は 'self' data:
+//     のみで外部ホストの画像は表示できないため、絶対 URL を持たせても無意味。
+const MAX_LENGTH = 2048;
+
+export class InvalidImageUrlError extends Error {
+  readonly name = "InvalidImageUrlError";
+}
+
+export class ImageUrl implements IValueObject<ImageUrl> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): ImageUrl {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidImageUrlError(
+        `Image URL must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    // ルート相対パスのみ。"//" 始まり (プロトコル相対 = 絶対 URL 相当) は弾く。
+    if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+      throw new InvalidImageUrlError(
+        "Image URL must be a root-relative asset path (e.g. /api/v1/notes/<slug>/assets/<file>)",
+      );
+    }
+    return new ImageUrl(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: ImageUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -1,0 +1,14 @@
+export { NoteNotFoundError } from "./errors";
+export { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+export { Note } from "./note.entity";
+export type { NoteId } from "./note.entity";
+export type { INoteCommandRepository } from "./note.command-repository.interface";
+export type {
+  INoteQueryRepository,
+  NoteListQuery,
+  NoteListResult,
+  NoteSortField,
+  SortDirection,
+} from "./note.query-repository.interface";

--- a/app/backend/domain/note/note-slug.vo.test.ts
+++ b/app/backend/domain/note/note-slug.vo.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+
+describe("NoteSlug", () => {
+  it("accepts lowercase alphanumerics with single hyphens", () => {
+    expect(NoteSlug.create("hello-world-2026").toString()).toBe(
+      "hello-world-2026",
+    );
+  });
+
+  it("trims and lowercases input", () => {
+    expect(NoteSlug.create("  Hello-World  ").toString()).toBe("hello-world");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => NoteSlug.create(" ".repeat(3))).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects leading, trailing, and doubled hyphens", () => {
+    expect(() => NoteSlug.create("-hello")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello-")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello--world")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects characters outside [a-z0-9-]", () => {
+    expect(() => NoteSlug.create("hello_world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("こんにちは")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects slugs longer than 200 characters", () => {
+    expect(() => NoteSlug.create("a".repeat(201))).toThrow(
+      InvalidNoteSlugError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("foo"))).toBe(true);
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("bar"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteSlug.create("foo-bar").toJSON()).toBe("foo-bar");
+  });
+});

--- a/app/backend/domain/note/note-slug.vo.ts
+++ b/app/backend/domain/note/note-slug.vo.ts
@@ -1,0 +1,47 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// スラグは URL パスセグメントに乗る識別子。小文字英数字とハイフンのみ許可する。
+// ハイフンの位置制約 (先頭・末尾・連続の禁止) はネストした量指定子の正規表現で
+// まとめて表現すると ReDoS 検知に触れるため、単純な文字クラス検査 + 個別チェックに分ける。
+const slugCharsPattern = /^[a-z0-9-]+$/;
+const MAX_LENGTH = 200;
+
+export class InvalidNoteSlugError extends Error {
+  readonly name = "InvalidNoteSlugError";
+}
+
+export class NoteSlug implements IValueObject<NoteSlug> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteSlug {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteSlugError(
+        `Note slug must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    if (
+      !slugCharsPattern.test(trimmed) ||
+      trimmed.startsWith("-") ||
+      trimmed.endsWith("-") ||
+      trimmed.includes("--")
+    ) {
+      throw new InvalidNoteSlugError(
+        "Note slug must be lowercase alphanumerics separated by single hyphens",
+      );
+    }
+    return new NoteSlug(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteSlug): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note-title.vo.test.ts
+++ b/app/backend/domain/note/note-title.vo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+
+describe("NoteTitle", () => {
+  it("keeps the original casing and symbols", () => {
+    expect(NoteTitle.create("Hello, World! 記事").toString()).toBe(
+      "Hello, World! 記事",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(NoteTitle.create("  Title  ").toString()).toBe("Title");
+  });
+
+  it("rejects empty or whitespace-only input", () => {
+    expect(() => NoteTitle.create("")).toThrow(InvalidNoteTitleError);
+    expect(() => NoteTitle.create(" ".repeat(3))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("rejects titles longer than 200 characters", () => {
+    expect(() => NoteTitle.create("あ".repeat(201))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteTitle.create("A").equals(NoteTitle.create("A"))).toBe(true);
+    expect(NoteTitle.create("A").equals(NoteTitle.create("B"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteTitle.create("Title").toJSON()).toBe("Title");
+  });
+});

--- a/app/backend/domain/note/note-title.vo.ts
+++ b/app/backend/domain/note/note-title.vo.ts
@@ -1,0 +1,35 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// タイトルはフロントマター由来の表示文字列。大文字小文字・記号はそのまま保つが、
+// 前後の空白は正規化し、空文字と過長を弾く。
+const MAX_LENGTH = 200;
+
+export class InvalidNoteTitleError extends Error {
+  readonly name = "InvalidNoteTitleError";
+}
+
+export class NoteTitle implements IValueObject<NoteTitle> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteTitle {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteTitleError(
+        `Note title must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    return new NoteTitle(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteTitle): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note.command-repository.interface.ts
+++ b/app/backend/domain/note/note.command-repository.interface.ts
@@ -1,0 +1,18 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note, NoteId } from "./note.entity";
+import type { IUnpersisted } from "~/backend/domain/shared";
+
+export interface INoteCommandRepository {
+  /**
+   * ノートのメタデータを slug をキーに upsert する。
+   * refresh 時に Artifacts の内容で D1 を同期するための操作。
+   * 既存 slug があれば更新、無ければ新規作成し、永続化済みエンティティを返す。
+   */
+  upsert(note: Note<IUnpersisted>): Promise<Note>;
+
+  /** slug のノートを削除する (Artifacts から消えたノートの掃除に使う)。 */
+  deleteBySlug(slug: NoteSlug): Promise<void>;
+
+  /** id のノートを削除する。 */
+  delete(id: NoteId): Promise<void>;
+}

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -1,0 +1,71 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { ImageUrl } from "./image-url.vo";
+import { NoteSlug } from "./note-slug.vo";
+import { NoteTitle } from "./note-title.vo";
+import { Note } from "./note.entity";
+import { entityId } from "~/backend/domain/shared";
+
+const slug = NoteSlug.create("my-note");
+const title = NoteTitle.create("My Note");
+const publishedOn = Temporal.PlainDate.from("2026-01-15");
+const lastModifiedOn = Temporal.PlainDate.from("2026-01-20");
+
+describe("Note.create", () => {
+  it("builds an unpersisted note with undefined id and timestamps", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "A short summary.",
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.id).toBeUndefined();
+    expect(note.createdAt).toBeUndefined();
+    expect(note.updatedAt).toBeUndefined();
+    expect(note.slug.toString()).toBe("my-note");
+    expect(note.title.toString()).toBe("My Note");
+    expect(note.summary).toBe("A short summary.");
+    expect(note.imageUrl).toBeUndefined();
+    expect(note.publishedOn.toString()).toBe("2026-01-15");
+    expect(note.lastModifiedOn.toString()).toBe("2026-01-20");
+  });
+
+  it("retains an optional cover image", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "s",
+      imageUrl: ImageUrl.create("/api/v1/notes/my-note/assets/cover.png"),
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.imageUrl?.toString()).toBe(
+      "/api/v1/notes/my-note/assets/cover.png",
+    );
+  });
+});
+
+describe("Note.reconstruct", () => {
+  it("restores a persisted note with id and timestamps", () => {
+    const createdAt = Temporal.Instant.from("2026-01-15T00:00:00Z");
+    const updatedAt = Temporal.Instant.from("2026-01-20T00:00:00Z");
+    const note = Note.reconstruct({
+      id: entityId<"Note">("note-1"),
+      slug,
+      title,
+      summary: "s",
+      imageUrl: undefined,
+      publishedOn,
+      lastModifiedOn,
+      createdAt,
+      updatedAt,
+    });
+
+    expect(note.id).toBe("note-1");
+    expect(note.createdAt.equals(createdAt)).toBe(true);
+    expect(note.updatedAt.equals(updatedAt)).toBe(true);
+  });
+});

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -1,0 +1,108 @@
+import type { ImageUrl } from "./image-url.vo";
+import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTitle } from "./note-title.vo";
+import type { Temporal } from "@js-temporal/polyfill";
+import type {
+  EntityId,
+  IPersisted,
+  IUnpersisted,
+} from "~/backend/domain/shared";
+
+export type NoteId = EntityId<"Note">;
+
+interface NoteFields<T extends IPersisted | IUnpersisted> {
+  readonly id: T["id"] extends string ? NoteId : undefined;
+  readonly slug: NoteSlug;
+  readonly title: NoteTitle;
+  /** MDAST から自動抽出した一覧用の要約 (先頭 160 文字)。手書きしない。 */
+  readonly summary: string;
+  /** カバー画像 URL。フロントマターに imageUrl が無ければ undefined。 */
+  readonly imageUrl: ImageUrl | undefined;
+  /** フロントマター由来の公開日 (日付のみ)。 */
+  readonly publishedOn: Temporal.PlainDate;
+  /** フロントマター由来の最終更新日 (日付のみ)。 */
+  readonly lastModifiedOn: Temporal.PlainDate;
+  /** D1 行の作成・更新時刻 (永続化メタデータ。コンテンツ日付とは別)。 */
+  readonly createdAt: T["createdAt"];
+  readonly updatedAt: T["updatedAt"];
+}
+
+/**
+ * ノート集約。Markdown 記事のメタデータを表す。
+ * 本文 (MDAST) と画像アセットは別ストレージ (R2) にあり、本エンティティは
+ * D1 のメタデータインデックスに対応する。
+ */
+export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
+  private constructor(private readonly fields: NoteFields<T>) {}
+
+  static create(params: {
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl?: ImageUrl;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+  }): Note<IUnpersisted> {
+    return new Note({
+      id: undefined,
+      slug: params.slug,
+      title: params.title,
+      summary: params.summary,
+      imageUrl: params.imageUrl,
+      publishedOn: params.publishedOn,
+      lastModifiedOn: params.lastModifiedOn,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  }
+
+  static reconstruct(params: {
+    id: NoteId;
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl: ImageUrl | undefined;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+    createdAt: Temporal.Instant;
+    updatedAt: Temporal.Instant;
+  }): Note {
+    return new Note(params);
+  }
+
+  get id(): NoteFields<T>["id"] {
+    return this.fields.id;
+  }
+
+  get slug(): NoteSlug {
+    return this.fields.slug;
+  }
+
+  get title(): NoteTitle {
+    return this.fields.title;
+  }
+
+  get summary(): string {
+    return this.fields.summary;
+  }
+
+  get imageUrl(): ImageUrl | undefined {
+    return this.fields.imageUrl;
+  }
+
+  get publishedOn(): Temporal.PlainDate {
+    return this.fields.publishedOn;
+  }
+
+  get lastModifiedOn(): Temporal.PlainDate {
+    return this.fields.lastModifiedOn;
+  }
+
+  get createdAt(): NoteFields<T>["createdAt"] {
+    return this.fields.createdAt;
+  }
+
+  get updatedAt(): NoteFields<T>["updatedAt"] {
+    return this.fields.updatedAt;
+  }
+}

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -1,0 +1,29 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note } from "./note.entity";
+
+/** 一覧の並び替え基準。 */
+export type NoteSortField = "publishedOn" | "lastModifiedOn";
+
+/** 並び順。 */
+export type SortDirection = "asc" | "desc";
+
+/** ページネーション + ソートのクエリ条件。 */
+export interface NoteListQuery {
+  /** 取得件数の上限 (1 以上)。 */
+  readonly limit: number;
+  /** スキップ件数 (0 以上)。 */
+  readonly offset: number;
+  readonly sortBy: NoteSortField;
+  readonly direction: SortDirection;
+}
+
+/** 一覧の取得結果。total は絞り込み前の全件数 (ページネーション用)。 */
+export interface NoteListResult {
+  readonly notes: readonly Note[];
+  readonly total: number;
+}
+
+export interface INoteQueryRepository {
+  findBySlug(slug: NoteSlug): Promise<Note | undefined>;
+  list(query: NoteListQuery): Promise<NoteListResult>;
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,11 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                               | Status   |
-| ------------------------------------------------------ | ------------------------------------------------------ | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する           | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する          | Accepted |
+| #                                                      | タイトル                                                   | Status   |
+| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
 | [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |


### PR DESCRIPTION
## 概要

Closes #4

ノート (Note) のドメイン層を実装する。既存 `user` ドメインのパターンに倣う。

## やったこと

- **Note エンティティ** (`note.entity.ts`) — `IPersisted` / `IUnpersisted` で永続化状態をコンパイル時に区別。`create` (未保存) / `reconstruct` (DB 復元)。
- **Value Objects**
  - `NoteSlug` — 小文字英数 + 単一ハイフンの kebab-case を正規化・検証 (URL スラグ)
  - `NoteTitle` — トリム済み非空・最大長
  - `ImageUrl` — **ルート相対のアセット API パスのみ**許可。絶対 URL (Artifacts 直接 URL) や未解決の相対パスは弾く
- **CQRS リポジトリインターフェース** — `INoteCommandRepository` (upsert / deleteBySlug / delete) と `INoteQueryRepository` (findBySlug / list)
- **ドメインエラー** — `NoteNotFoundError`
- **ユニットテスト** — VO 3 種 + エンティティ (計 24 ケース)

## 設計判断

- `ImageUrl` を絶対 URL 不許可にしたのは、product 規約「Artifacts の直接 URL を露出させない」と CSP `img-src 'self'` の両方に整合させるため。画像は必ずアセット API 経由 (self) で配信する。
- `NoteSlug` は URL 命名規則 (kebab-case) に従い小文字正規化する。Artifacts ファイル名との対応付けは refresh (#7) の責務。

## 付随変更

- 既存 docs (`.claude/rules/*.md`, `docs/adr/README.md`) の prettier 整形ドリフトを修正。これらは初回コミットが PR を経ず main に入ったため `format` チェック未通過のまま残っていたもので、本 PR の `format` を緑にするために同梱した。

## CI について

⚠️ `deploy-preview` は `CLOUDFLARE_API_TOKEN` 等の GitHub Secrets 未設定により失敗します (認証情報が無いための環境要因)。コード品質チェック (format / eslint / typecheck / wrangler-config / migration-check / storybook / test / title / branch) は全て pass します。Secrets 設定後にデプロイも緑化する想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S