### PR TITLE
feat(handlers): ノート一覧 API とページを実装する

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -1,7 +1,7 @@
 # 環境構成
 
-| 環境        | トリガー          | DB                                         |
-| ----------- | ----------------- | ------------------------------------------ |
+| 環境        | トリガー          | DB                          |
+| ----------- | ----------------- | --------------------------- |
 | development | ローカル          | yantene-development (local) |
 | staging     | PR / push to main | yantene-staging             |
 | production  | GitHub Release    | yantene-production          |

--- a/.claude/rules/product.md
+++ b/.claude/rules/product.md
@@ -51,7 +51,7 @@ NoteTitle / ImageUrl 等の VO に変換する。
 ```yaml
 ---
 title: 記事タイトル
-imageUrl: ./cover.png       # 相対パス → アセット API URL に解決される
+imageUrl: ./cover.png # 相対パス → アセット API URL に解決される
 publishedOn: 2026-01-15
 lastModifiedOn: 2026-01-20
 ---

--- a/app/backend/domain/note/errors.ts
+++ b/app/backend/domain/note/errors.ts
@@ -1,0 +1,6 @@
+export class NoteNotFoundError extends Error {
+  readonly name = "NoteNotFoundError";
+  constructor(slug: string) {
+    super(`Note not found: ${slug}`);
+  }
+}

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+
+describe("ImageUrl", () => {
+  it("accepts a root-relative asset API path", () => {
+    const url = "/api/v1/notes/my-note/assets/cover.png";
+    expect(ImageUrl.create(url).toString()).toBe(url);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(ImageUrl.create("  /a/b.png  ").toString()).toBe("/a/b.png");
+  });
+
+  it("rejects unresolved relative paths", () => {
+    expect(() => ImageUrl.create("./cover.png")).toThrow(InvalidImageUrlError);
+    expect(() => ImageUrl.create("cover.png")).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects absolute URLs, including raw Artifacts URLs", () => {
+    // 絶対 URL は Artifacts の直接 URL 露出につながり、CSP (img-src 'self') でも
+    // 表示できないため弾く。
+    expect(() => ImageUrl.create("https://example.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() =>
+      ImageUrl.create("https://artifacts.example/raw/notes/x/cover.png"),
+    ).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects protocol-relative and non-http schemes", () => {
+    expect(() => ImageUrl.create("//evil.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("javascript:alert(1)")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("data:image/png;base64,AAAA")).toThrow(
+      InvalidImageUrlError,
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => ImageUrl.create(" ".repeat(3))).toThrow(InvalidImageUrlError);
+  });
+
+  it("compares by value with equals", () => {
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/a.png"))).toBe(
+      true,
+    );
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/b.png"))).toBe(
+      false,
+    );
+  });
+});

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -1,0 +1,48 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// ノートのカバー画像 URL。フロントマターの相対パス (`./cover.png`) は
+// アセット API URL (ルート相対 `/api/v1/notes/<slug>/assets/...`) に解決してから
+// VO 化する前提で、ここでは解決済みの「ルート相対パス」だけを受け入れる。
+//
+// 絶対 URL は弾く。これは 2 つの規約を同時に満たすため:
+//   - Artifacts の直接 URL を露出させない (product 規約)。絶対 URL を許すと
+//     未解決の生 Artifacts URL がそのまま通り得る。
+//   - 画像はアセット API (self) 経由で配信する。CSP の img-src は 'self' data:
+//     のみで外部ホストの画像は表示できないため、絶対 URL を持たせても無意味。
+const MAX_LENGTH = 2048;
+
+export class InvalidImageUrlError extends Error {
+  readonly name = "InvalidImageUrlError";
+}
+
+export class ImageUrl implements IValueObject<ImageUrl> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): ImageUrl {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidImageUrlError(
+        `Image URL must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    // ルート相対パスのみ。"//" 始まり (プロトコル相対 = 絶対 URL 相当) は弾く。
+    if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+      throw new InvalidImageUrlError(
+        "Image URL must be a root-relative asset path (e.g. /api/v1/notes/<slug>/assets/<file>)",
+      );
+    }
+    return new ImageUrl(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: ImageUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -1,0 +1,14 @@
+export { NoteNotFoundError } from "./errors";
+export { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+export { Note } from "./note.entity";
+export type { NoteId } from "./note.entity";
+export type { INoteCommandRepository } from "./note.command-repository.interface";
+export type {
+  INoteQueryRepository,
+  NoteListQuery,
+  NoteListResult,
+  NoteSortField,
+  SortDirection,
+} from "./note.query-repository.interface";

--- a/app/backend/domain/note/note-slug.vo.test.ts
+++ b/app/backend/domain/note/note-slug.vo.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+
+describe("NoteSlug", () => {
+  it("accepts lowercase alphanumerics with single hyphens", () => {
+    expect(NoteSlug.create("hello-world-2026").toString()).toBe(
+      "hello-world-2026",
+    );
+  });
+
+  it("trims and lowercases input", () => {
+    expect(NoteSlug.create("  Hello-World  ").toString()).toBe("hello-world");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => NoteSlug.create(" ".repeat(3))).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects leading, trailing, and doubled hyphens", () => {
+    expect(() => NoteSlug.create("-hello")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello-")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello--world")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects characters outside [a-z0-9-]", () => {
+    expect(() => NoteSlug.create("hello_world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("こんにちは")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects slugs longer than 200 characters", () => {
+    expect(() => NoteSlug.create("a".repeat(201))).toThrow(
+      InvalidNoteSlugError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("foo"))).toBe(true);
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("bar"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteSlug.create("foo-bar").toJSON()).toBe("foo-bar");
+  });
+});

--- a/app/backend/domain/note/note-slug.vo.ts
+++ b/app/backend/domain/note/note-slug.vo.ts
@@ -1,0 +1,47 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// スラグは URL パスセグメントに乗る識別子。小文字英数字とハイフンのみ許可する。
+// ハイフンの位置制約 (先頭・末尾・連続の禁止) はネストした量指定子の正規表現で
+// まとめて表現すると ReDoS 検知に触れるため、単純な文字クラス検査 + 個別チェックに分ける。
+const slugCharsPattern = /^[a-z0-9-]+$/;
+const MAX_LENGTH = 200;
+
+export class InvalidNoteSlugError extends Error {
+  readonly name = "InvalidNoteSlugError";
+}
+
+export class NoteSlug implements IValueObject<NoteSlug> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteSlug {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteSlugError(
+        `Note slug must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    if (
+      !slugCharsPattern.test(trimmed) ||
+      trimmed.startsWith("-") ||
+      trimmed.endsWith("-") ||
+      trimmed.includes("--")
+    ) {
+      throw new InvalidNoteSlugError(
+        "Note slug must be lowercase alphanumerics separated by single hyphens",
+      );
+    }
+    return new NoteSlug(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteSlug): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note-title.vo.test.ts
+++ b/app/backend/domain/note/note-title.vo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+
+describe("NoteTitle", () => {
+  it("keeps the original casing and symbols", () => {
+    expect(NoteTitle.create("Hello, World! 記事").toString()).toBe(
+      "Hello, World! 記事",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(NoteTitle.create("  Title  ").toString()).toBe("Title");
+  });
+
+  it("rejects empty or whitespace-only input", () => {
+    expect(() => NoteTitle.create("")).toThrow(InvalidNoteTitleError);
+    expect(() => NoteTitle.create(" ".repeat(3))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("rejects titles longer than 200 characters", () => {
+    expect(() => NoteTitle.create("あ".repeat(201))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteTitle.create("A").equals(NoteTitle.create("A"))).toBe(true);
+    expect(NoteTitle.create("A").equals(NoteTitle.create("B"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteTitle.create("Title").toJSON()).toBe("Title");
+  });
+});

--- a/app/backend/domain/note/note-title.vo.ts
+++ b/app/backend/domain/note/note-title.vo.ts
@@ -1,0 +1,35 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// タイトルはフロントマター由来の表示文字列。大文字小文字・記号はそのまま保つが、
+// 前後の空白は正規化し、空文字と過長を弾く。
+const MAX_LENGTH = 200;
+
+export class InvalidNoteTitleError extends Error {
+  readonly name = "InvalidNoteTitleError";
+}
+
+export class NoteTitle implements IValueObject<NoteTitle> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteTitle {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteTitleError(
+        `Note title must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    return new NoteTitle(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteTitle): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note.command-repository.interface.ts
+++ b/app/backend/domain/note/note.command-repository.interface.ts
@@ -1,0 +1,18 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note, NoteId } from "./note.entity";
+import type { IUnpersisted } from "~/backend/domain/shared";
+
+export interface INoteCommandRepository {
+  /**
+   * ノートのメタデータを slug をキーに upsert する。
+   * refresh 時に Artifacts の内容で D1 を同期するための操作。
+   * 既存 slug があれば更新、無ければ新規作成し、永続化済みエンティティを返す。
+   */
+  upsert(note: Note<IUnpersisted>): Promise<Note>;
+
+  /** slug のノートを削除する (Artifacts から消えたノートの掃除に使う)。 */
+  deleteBySlug(slug: NoteSlug): Promise<void>;
+
+  /** id のノートを削除する。 */
+  delete(id: NoteId): Promise<void>;
+}

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -1,0 +1,71 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { ImageUrl } from "./image-url.vo";
+import { NoteSlug } from "./note-slug.vo";
+import { NoteTitle } from "./note-title.vo";
+import { Note } from "./note.entity";
+import { entityId } from "~/backend/domain/shared";
+
+const slug = NoteSlug.create("my-note");
+const title = NoteTitle.create("My Note");
+const publishedOn = Temporal.PlainDate.from("2026-01-15");
+const lastModifiedOn = Temporal.PlainDate.from("2026-01-20");
+
+describe("Note.create", () => {
+  it("builds an unpersisted note with undefined id and timestamps", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "A short summary.",
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.id).toBeUndefined();
+    expect(note.createdAt).toBeUndefined();
+    expect(note.updatedAt).toBeUndefined();
+    expect(note.slug.toString()).toBe("my-note");
+    expect(note.title.toString()).toBe("My Note");
+    expect(note.summary).toBe("A short summary.");
+    expect(note.imageUrl).toBeUndefined();
+    expect(note.publishedOn.toString()).toBe("2026-01-15");
+    expect(note.lastModifiedOn.toString()).toBe("2026-01-20");
+  });
+
+  it("retains an optional cover image", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "s",
+      imageUrl: ImageUrl.create("/api/v1/notes/my-note/assets/cover.png"),
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.imageUrl?.toString()).toBe(
+      "/api/v1/notes/my-note/assets/cover.png",
+    );
+  });
+});
+
+describe("Note.reconstruct", () => {
+  it("restores a persisted note with id and timestamps", () => {
+    const createdAt = Temporal.Instant.from("2026-01-15T00:00:00Z");
+    const updatedAt = Temporal.Instant.from("2026-01-20T00:00:00Z");
+    const note = Note.reconstruct({
+      id: entityId<"Note">("note-1"),
+      slug,
+      title,
+      summary: "s",
+      imageUrl: undefined,
+      publishedOn,
+      lastModifiedOn,
+      createdAt,
+      updatedAt,
+    });
+
+    expect(note.id).toBe("note-1");
+    expect(note.createdAt.equals(createdAt)).toBe(true);
+    expect(note.updatedAt.equals(updatedAt)).toBe(true);
+  });
+});

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -1,0 +1,108 @@
+import type { ImageUrl } from "./image-url.vo";
+import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTitle } from "./note-title.vo";
+import type { Temporal } from "@js-temporal/polyfill";
+import type {
+  EntityId,
+  IPersisted,
+  IUnpersisted,
+} from "~/backend/domain/shared";
+
+export type NoteId = EntityId<"Note">;
+
+interface NoteFields<T extends IPersisted | IUnpersisted> {
+  readonly id: T["id"] extends string ? NoteId : undefined;
+  readonly slug: NoteSlug;
+  readonly title: NoteTitle;
+  /** MDAST から自動抽出した一覧用の要約 (先頭 160 文字)。手書きしない。 */
+  readonly summary: string;
+  /** カバー画像 URL。フロントマターに imageUrl が無ければ undefined。 */
+  readonly imageUrl: ImageUrl | undefined;
+  /** フロントマター由来の公開日 (日付のみ)。 */
+  readonly publishedOn: Temporal.PlainDate;
+  /** フロントマター由来の最終更新日 (日付のみ)。 */
+  readonly lastModifiedOn: Temporal.PlainDate;
+  /** D1 行の作成・更新時刻 (永続化メタデータ。コンテンツ日付とは別)。 */
+  readonly createdAt: T["createdAt"];
+  readonly updatedAt: T["updatedAt"];
+}
+
+/**
+ * ノート集約。Markdown 記事のメタデータを表す。
+ * 本文 (MDAST) と画像アセットは別ストレージ (R2) にあり、本エンティティは
+ * D1 のメタデータインデックスに対応する。
+ */
+export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
+  private constructor(private readonly fields: NoteFields<T>) {}
+
+  static create(params: {
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl?: ImageUrl;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+  }): Note<IUnpersisted> {
+    return new Note({
+      id: undefined,
+      slug: params.slug,
+      title: params.title,
+      summary: params.summary,
+      imageUrl: params.imageUrl,
+      publishedOn: params.publishedOn,
+      lastModifiedOn: params.lastModifiedOn,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  }
+
+  static reconstruct(params: {
+    id: NoteId;
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl: ImageUrl | undefined;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+    createdAt: Temporal.Instant;
+    updatedAt: Temporal.Instant;
+  }): Note {
+    return new Note(params);
+  }
+
+  get id(): NoteFields<T>["id"] {
+    return this.fields.id;
+  }
+
+  get slug(): NoteSlug {
+    return this.fields.slug;
+  }
+
+  get title(): NoteTitle {
+    return this.fields.title;
+  }
+
+  get summary(): string {
+    return this.fields.summary;
+  }
+
+  get imageUrl(): ImageUrl | undefined {
+    return this.fields.imageUrl;
+  }
+
+  get publishedOn(): Temporal.PlainDate {
+    return this.fields.publishedOn;
+  }
+
+  get lastModifiedOn(): Temporal.PlainDate {
+    return this.fields.lastModifiedOn;
+  }
+
+  get createdAt(): NoteFields<T>["createdAt"] {
+    return this.fields.createdAt;
+  }
+
+  get updatedAt(): NoteFields<T>["updatedAt"] {
+    return this.fields.updatedAt;
+  }
+}

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -1,0 +1,29 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note } from "./note.entity";
+
+/** 一覧の並び替え基準。 */
+export type NoteSortField = "publishedOn" | "lastModifiedOn";
+
+/** 並び順。 */
+export type SortDirection = "asc" | "desc";
+
+/** ページネーション + ソートのクエリ条件。 */
+export interface NoteListQuery {
+  /** 取得件数の上限 (1 以上)。 */
+  readonly limit: number;
+  /** スキップ件数 (0 以上)。 */
+  readonly offset: number;
+  readonly sortBy: NoteSortField;
+  readonly direction: SortDirection;
+}
+
+/** 一覧の取得結果。total は絞り込み前の全件数 (ページネーション用)。 */
+export interface NoteListResult {
+  readonly notes: readonly Note[];
+  readonly total: number;
+}
+
+export interface INoteQueryRepository {
+  findBySlug(slug: NoteSlug): Promise<Note | undefined>;
+  list(query: NoteListQuery): Promise<NoteListResult>;
+}

--- a/app/backend/handlers/note-view.test.ts
+++ b/app/backend/handlers/note-view.test.ts
@@ -31,6 +31,11 @@ describe("parsePagination", () => {
     expect(parsePagination("abc", "x")).toMatchObject({ page: 1, perPage: 20 });
     expect(parsePagination("-5", undefined).page).toBe(1);
   });
+
+  it("treats empty / whitespace params as missing (uses defaults)", () => {
+    expect(parsePagination("", "")).toMatchObject({ page: 1, perPage: 20 });
+    expect(parsePagination("  ", " ")).toMatchObject({ page: 1, perPage: 20 });
+  });
 });
 
 describe("parseNoteSort", () => {

--- a/app/backend/handlers/note-view.test.ts
+++ b/app/backend/handlers/note-view.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseNoteSort, parsePagination } from "./note-view";
+
+describe("parsePagination", () => {
+  it("defaults to page 1 and per-page 20", () => {
+    expect(parsePagination(undefined, undefined)).toEqual({
+      page: 1,
+      perPage: 20,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("computes offset from page and per-page", () => {
+    expect(parsePagination("3", "10")).toEqual({
+      page: 3,
+      perPage: 10,
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  it("clamps per-page to the 1..100 range", () => {
+    expect(parsePagination("1", "1000").perPage).toBe(100);
+    // 範囲外 (0) は境界 (min 1) に丸める。非数値のみ既定 (20) に落ちる。
+    expect(parsePagination("1", "0").perPage).toBe(1);
+    expect(parsePagination("1", "x").perPage).toBe(20);
+  });
+
+  it("falls back to defaults on non-numeric or negative input", () => {
+    expect(parsePagination("abc", "x")).toMatchObject({ page: 1, perPage: 20 });
+    expect(parsePagination("-5", undefined).page).toBe(1);
+  });
+});
+
+describe("parseNoteSort", () => {
+  it("defaults to publishedOn descending", () => {
+    expect(parseNoteSort(undefined, undefined)).toEqual({
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+  });
+
+  it("maps 'modified' to lastModifiedOn and 'asc' to ascending", () => {
+    expect(parseNoteSort("modified", "asc")).toEqual({
+      sortBy: "lastModifiedOn",
+      direction: "asc",
+    });
+  });
+
+  it("treats unknown values as the safe defaults", () => {
+    expect(parseNoteSort("bogus", "bogus")).toEqual({
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+  });
+});

--- a/app/backend/handlers/note-view.ts
+++ b/app/backend/handlers/note-view.ts
@@ -49,13 +49,15 @@ export function toPublicNoteList(
   page: number,
   perPage: number,
 ): PublicNoteList {
+  const totalPages = Math.max(1, Math.ceil(result.total / perPage));
   return {
     notes: result.notes.map((note) => toPublicNote(note)),
     pagination: {
-      page,
+      // 範囲外のページ番号は totalPages に丸めて pager と整合させる。
+      page: Math.min(page, totalPages),
       perPage,
       total: result.total,
-      totalPages: Math.max(1, Math.ceil(result.total / perPage)),
+      totalPages,
     },
   };
 }
@@ -82,7 +84,10 @@ function clampInt(
   min: number,
   max: number,
 ): number {
-  const parsed = raw === undefined ? NaN : Number(raw);
+  // 未指定・空文字は「未指定」として既定値に落とす (Number("") === 0 の罠を避ける)。
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return fallback;
+  const parsed = Number(trimmed);
   if (!Number.isSafeInteger(parsed)) return fallback;
   return Math.min(Math.max(parsed, min), max);
 }

--- a/app/backend/handlers/note-view.ts
+++ b/app/backend/handlers/note-view.ts
@@ -1,0 +1,99 @@
+import type {
+  Note,
+  NoteListResult,
+  NoteSortField,
+  SortDirection,
+} from "~/backend/domain/note";
+
+/**
+ * 外部 (JSON API / Inertia props) に公開してよい Note の表現。
+ * ドメインエンティティをそのまま晒さず、公開可能なフィールドだけに絞る。
+ * 識別子は slug (URL 用) のみ公開し、内部 id は出さない。
+ */
+export interface PublicNote {
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly imageUrl: string | null;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+}
+
+export interface Pagination {
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+  readonly totalPages: number;
+}
+
+export interface PublicNoteList {
+  readonly notes: readonly PublicNote[];
+  readonly pagination: Pagination;
+}
+
+/** Note エンティティを公開 DTO へ変換する (API / pages 共通)。 */
+export function toPublicNote(note: Note): PublicNote {
+  return {
+    slug: note.slug.toJSON(),
+    title: note.title.toJSON(),
+    summary: note.summary,
+    imageUrl: note.imageUrl?.toJSON() ?? null,
+    publishedOn: note.publishedOn.toString({ calendarName: "never" }),
+    lastModifiedOn: note.lastModifiedOn.toString({ calendarName: "never" }),
+  };
+}
+
+/** ページネーション付きの一覧結果を公開 DTO へ変換する。 */
+export function toPublicNoteList(
+  result: NoteListResult,
+  page: number,
+  perPage: number,
+): PublicNoteList {
+  return {
+    notes: result.notes.map((note) => toPublicNote(note)),
+    pagination: {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.max(1, Math.ceil(result.total / perPage)),
+    },
+  };
+}
+
+const DEFAULT_PER_PAGE = 20;
+const MAX_PER_PAGE = 100;
+
+/**
+ * クエリ文字列 (page / per-page) を検証済みのページネーションに解決する。
+ * 不正・範囲外は安全側 (page>=1, 1<=perPage<=100) に丸める。
+ */
+export function parsePagination(
+  pageParam: string | undefined,
+  perPageParam: string | undefined,
+): { page: number; perPage: number; limit: number; offset: number } {
+  const page = clampInt(pageParam, 1, 1, Number.MAX_SAFE_INTEGER);
+  const perPage = clampInt(perPageParam, DEFAULT_PER_PAGE, 1, MAX_PER_PAGE);
+  return { page, perPage, limit: perPage, offset: (page - 1) * perPage };
+}
+
+function clampInt(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+/** クエリ文字列 (sort-by / order) を検証済みのソート指定に解決する。 */
+export function parseNoteSort(
+  sortByParam: string | undefined,
+  orderParam: string | undefined,
+): { sortBy: NoteSortField; direction: SortDirection } {
+  const sortBy: NoteSortField =
+    sortByParam === "modified" ? "lastModifiedOn" : "publishedOn";
+  const direction: SortDirection = orderParam === "asc" ? "asc" : "desc";
+  return { sortBy, direction };
+}

--- a/app/backend/handlers/notes/list-api.handler.test.ts
+++ b/app/backend/handlers/notes/list-api.handler.test.ts
@@ -1,0 +1,102 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { createNotesApiRouter } from "./list-api.handler";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import type { PublicNoteList } from "~/backend/handlers/note-view";
+import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { D1NoteCommandRepository } from "~/backend/infra/d1/repositories";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function note(slug: string, publishedOn: string): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(slug),
+    title: NoteTitle.create(slug),
+    summary: `summary of ${slug}`,
+    publishedOn: Temporal.PlainDate.from(publishedOn),
+    lastModifiedOn: Temporal.PlainDate.from(publishedOn),
+  });
+}
+
+async function seed(d1: D1Database): Promise<void> {
+  const cmd = new D1NoteCommandRepository(d1);
+  await cmd.upsert(note("a", "2026-01-10"));
+  await cmd.upsert(note("b", "2026-03-10"));
+  await cmd.upsert(note("c", "2026-02-10"));
+}
+
+function envWith(d1: D1Database): Env {
+  return { D1: d1 } as unknown as Env;
+}
+
+/**
+ * GET / を叩いてボディを PublicNoteList として取り出す。Hono の request() 応答型は
+ * ここでは解決できないため、text() → JSON.parse で明示的に読み取る。
+ */
+async function fetchList(d1: D1Database, query = ""): Promise<PublicNoteList> {
+  const res = await createNotesApiRouter().request(
+    `/${query}`,
+    {},
+    envWith(d1),
+  );
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  return JSON.parse(text) as PublicNoteList;
+}
+
+describe("createNotesApiRouter GET /", () => {
+  it("returns notes without requiring a session (public)", async () => {
+    const d1 = createTestD1();
+    await seed(d1);
+
+    const body = await fetchList(d1);
+    expect(body.pagination).toEqual({
+      page: 1,
+      perPage: 20,
+      total: 3,
+      totalPages: 1,
+    });
+    // 既定は publishedOn 降順。
+    expect(body.notes.map((n) => n.slug)).toEqual(["b", "c", "a"]);
+  });
+
+  it("paginates with page and per-page", async () => {
+    const d1 = createTestD1();
+    await seed(d1);
+
+    const body = await fetchList(d1, "?page=2&per-page=2");
+    expect(body.pagination).toEqual({
+      page: 2,
+      perPage: 2,
+      total: 3,
+      totalPages: 2,
+    });
+    expect(body.notes.map((n) => n.slug)).toEqual(["a"]);
+  });
+
+  it("sorts ascending when order=asc", async () => {
+    const d1 = createTestD1();
+    await seed(d1);
+
+    const body = await fetchList(d1, "?sort-by=published&order=asc");
+    expect(body.notes.map((n) => n.slug)).toEqual(["a", "c", "b"]);
+  });
+
+  it("exposes only public fields and null imageUrl when absent", async () => {
+    const d1 = createTestD1();
+    await seed(d1);
+
+    const body = await fetchList(d1);
+    const first = body.notes[0];
+
+    expect(Object.keys(first).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      "imageUrl",
+      "lastModifiedOn",
+      "publishedOn",
+      "slug",
+      "summary",
+      "title",
+    ]);
+    expect(first.imageUrl).toBeNull();
+    expect(first.publishedOn).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/app/backend/handlers/notes/list-api.handler.test.ts
+++ b/app/backend/handlers/notes/list-api.handler.test.ts
@@ -73,6 +73,16 @@ describe("createNotesApiRouter GET /", () => {
     expect(body.notes.map((n) => n.slug)).toEqual(["a"]);
   });
 
+  it("clamps an out-of-range page to totalPages", async () => {
+    const d1 = createTestD1();
+    await seed(d1);
+
+    const body = await fetchList(d1, "?page=9999&per-page=2");
+    // 3 件 / per-page 2 → 2 ページ。9999 は 2 に丸められる。
+    expect(body.pagination.totalPages).toBe(2);
+    expect(body.pagination.page).toBe(2);
+  });
+
   it("sorts ascending when order=asc", async () => {
     const d1 = createTestD1();
     await seed(d1);

--- a/app/backend/handlers/notes/list-api.handler.ts
+++ b/app/backend/handlers/notes/list-api.handler.ts
@@ -1,0 +1,35 @@
+import { Hono } from "hono";
+import {
+  parseNoteSort,
+  parsePagination,
+  toPublicNoteList,
+} from "~/backend/handlers/note-view";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+/**
+ * ノートの公開 JSON API ルータ。認証不要 (クローラー・ボット対応のため)。
+ * index.ts で auth ガードより前にマウントし、`/api/v1/notes` 配下を公開する。
+ *
+ * GET /  → 一覧 (ページネーション + ソート)
+ *   query: page, per-page, sort-by (published|modified), order (asc|desc)
+ */
+export function createNotesApiRouter(): Hono<{ Bindings: Env }> {
+  const router = new Hono<{ Bindings: Env }>();
+
+  router.get("/", async (c) => {
+    const { page, perPage, limit, offset } = parsePagination(
+      c.req.query("page"),
+      c.req.query("per-page"),
+    );
+    const { sortBy, direction } = parseNoteSort(
+      c.req.query("sort-by"),
+      c.req.query("order"),
+    );
+
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const result = await query.list({ limit, offset, sortBy, direction });
+    return c.json(toPublicNoteList(result, page, perPage));
+  });
+
+  return router;
+}

--- a/app/backend/handlers/notes/pages.handler.ts
+++ b/app/backend/handlers/notes/pages.handler.ts
@@ -1,0 +1,43 @@
+import { Hono } from "hono";
+import type { LocaleVariables } from "~/backend/middleware/locale";
+import {
+  parseNoteSort,
+  parsePagination,
+  toPublicNoteList,
+} from "~/backend/handlers/note-view";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+type NotesPagesBindings = {
+  Bindings: Env;
+  Variables: LocaleVariables;
+};
+
+/**
+ * ノートの公開ページルータ (Inertia)。認証不要 (クローラー・ボット対応)。
+ * createPagesRouter 内で locale + inertia ミドルウェア適用後・auth ガードより前に
+ * マウントし、ミドルウェアを継承しつつ公開する。
+ */
+export function createNotesPagesRouter(): Hono<NotesPagesBindings> {
+  const router = new Hono<NotesPagesBindings>();
+
+  router.get("/notes", async (c) => {
+    const { page, perPage, limit, offset } = parsePagination(
+      c.req.query("page"),
+      c.req.query("per-page"),
+    );
+    const { sortBy, direction } = parseNoteSort(
+      c.req.query("sort-by"),
+      c.req.query("order"),
+    );
+
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const result = await query.list({ limit, offset, sortBy, direction });
+
+    return c.render("notes/index", {
+      locale: c.get("locale"),
+      ...toPublicNoteList(result, page, perPage),
+    });
+  });
+
+  return router;
+}

--- a/app/backend/handlers/notes/pages.handler.ts
+++ b/app/backend/handlers/notes/pages.handler.ts
@@ -36,6 +36,11 @@ export function createNotesPagesRouter(): Hono<NotesPagesBindings> {
     return c.render("notes/index", {
       locale: c.get("locale"),
       ...toPublicNoteList(result, page, perPage),
+      // ページ送りリンクで現在の並び順を保持するため、生のクエリ値を渡す。
+      sort: {
+        sortBy: c.req.query("sort-by") ?? null,
+        order: c.req.query("order") ?? null,
+      },
     });
   });
 

--- a/app/backend/handlers/notes/public-routing.test.ts
+++ b/app/backend/handlers/notes/public-routing.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import app from "~/backend/index";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+/**
+ * 公開ノート API が認証ガードより前にマウントされ、応答して短絡することで
+ * `/api/*` の requireSession を通さないことを、実アプリの合成で検証する。
+ * 同時に既存の認証必須 API (`/api/me`) が保護されたままであることも確認する。
+ */
+describe("notes public routing", () => {
+  function env(): Env {
+    return { D1: createTestD1(), KV: {} } as unknown as Env;
+  }
+
+  it("serves GET /api/v1/notes without a session (public)", async () => {
+    const res = await app.request("/api/v1/notes", {}, env());
+    expect(res.status).toBe(200);
+  });
+
+  it("still protects GET /api/me behind the session guard", async () => {
+    const res = await app.request("/api/me", {}, env());
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -4,6 +4,7 @@ import { toPublicUser } from "./user-view";
 import { entityId } from "~/backend/domain/shared";
 import { createLogoutRouter } from "~/backend/handlers/auth/logout.handler";
 import { createMagicLinkRouter } from "~/backend/handlers/auth/magic-link.handler";
+import { createNotesPagesRouter } from "~/backend/handlers/notes/pages.handler";
 import { D1UserQueryRepository } from "~/backend/infra/d1/repositories";
 import { requireSessionOrRedirect } from "~/backend/middleware/auth";
 import {
@@ -36,6 +37,9 @@ export function createPagesRouter(): Hono<PagesBindings> {
 
   router.route("/", createMagicLinkRouter());
   router.route("/", createLogoutRouter());
+
+  // ノートの公開ページ (認証不要・クローラー対応)。auth ガードより前にマウントする。
+  router.route("/", createNotesPagesRouter());
 
   // 以降は認証必須
   router.use("*", requireSessionOrRedirect);

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -6,6 +6,7 @@ import {
   type SecureHeadersVariables,
 } from "hono/secure-headers";
 import { createApiRouter } from "./handlers/api";
+import { createNotesApiRouter } from "./handlers/notes/list-api.handler";
 import { createPagesRouter } from "./handlers/pages";
 import { UserNotFoundError } from "~/backend/domain/user";
 import { requireSession } from "~/backend/middleware/auth";
@@ -46,6 +47,10 @@ app.use("*", conditionalBasicAuth);
 
 // public health endpoint (auth 不要)
 app.get("/health", (c) => c.json({ status: "ok" }));
+
+// ノートの公開 JSON API (認証不要・クローラー対応)。requireSession より前に
+// マウントし、ハンドラが応答して短絡することで /api/* の認証ガードを通さない。
+app.route("/api/v1/notes", createNotesApiRouter());
 
 // 認証必須 JSON API
 app.use("/api/*", requireSession);

--- a/app/backend/infra/d1/repositories/index.ts
+++ b/app/backend/infra/d1/repositories/index.ts
@@ -1,2 +1,4 @@
+export { D1NoteCommandRepository } from "./note.command-repository";
+export { D1NoteQueryRepository } from "./note.query-repository";
 export { D1UserCommandRepository } from "./user.command-repository";
 export { D1UserQueryRepository } from "./user.query-repository";

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -1,0 +1,23 @@
+import type { notes } from "~/backend/infra/d1/schema";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { entityId } from "~/backend/domain/shared";
+import { isoToPlainDate, unixToInstant } from "~/backend/infra/d1/temporal";
+
+/**
+ * D1 の行を Note エンティティに復元する。Command / Query リポジトリで共有する。
+ * slug / title / imageUrl は保存時に VO 経由で検証済みなので、ここでの再検証は
+ * 破損データの検知を兼ねる (不正なら VO factory が throw する)。
+ */
+export function rowToNote(row: typeof notes.$inferSelect): Note {
+  return Note.reconstruct({
+    id: entityId<"Note">(row.id),
+    slug: NoteSlug.create(row.slug),
+    title: NoteTitle.create(row.title),
+    summary: row.summary,
+    imageUrl: row.imageUrl === null ? undefined : ImageUrl.create(row.imageUrl),
+    publishedOn: isoToPlainDate(row.publishedOn),
+    lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
+    createdAt: unixToInstant(row.createdAt),
+    updatedAt: unixToInstant(row.updatedAt),
+  });
+}

--- a/app/backend/infra/d1/repositories/note.command-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.test.ts
@@ -1,0 +1,109 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function unpersistedNote(params: {
+  slug: string;
+  title: string;
+  summary?: string;
+  imageUrl?: string;
+  publishedOn?: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.title),
+    summary: params.summary ?? "summary",
+    imageUrl:
+      params.imageUrl === undefined
+        ? undefined
+        : ImageUrl.create(params.imageUrl),
+    publishedOn: Temporal.PlainDate.from(params.publishedOn ?? "2026-01-15"),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? "2026-01-20",
+    ),
+  });
+}
+
+describe("D1NoteCommandRepository", () => {
+  it("inserts a new note and returns it persisted", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+
+    const saved = await cmd.upsert(
+      unpersistedNote({
+        slug: "hello",
+        title: "Hello",
+        imageUrl: "/api/v1/notes/hello/assets/cover.png",
+      }),
+    );
+
+    expect(saved.id).toBeTruthy();
+    expect(saved.slug.toString()).toBe("hello");
+    expect(saved.title.toString()).toBe("Hello");
+    expect(saved.imageUrl?.toString()).toBe(
+      "/api/v1/notes/hello/assets/cover.png",
+    );
+    expect(saved.createdAt).toBeInstanceOf(Temporal.Instant);
+    expect(saved.updatedAt).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("stores a note without a cover image as undefined", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+    const saved = await cmd.upsert(unpersistedNote({ slug: "x", title: "X" }));
+    expect(saved.imageUrl).toBeUndefined();
+  });
+
+  it("updates in place on slug conflict, keeping the same id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const first = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Original" }),
+    );
+    const second = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Updated", summary: "new" }),
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.title.toString()).toBe("Updated");
+    expect(second.summary).toBe("new");
+    expect(second.createdAt.equals(first.createdAt)).toBe(true);
+
+    const { total } = await query.list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    expect(total).toBe(1);
+  });
+
+  it("deletes a note by slug", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    await cmd.upsert(unpersistedNote({ slug: "gone", title: "Gone" }));
+    await cmd.deleteBySlug(NoteSlug.create("gone"));
+
+    expect(await query.findBySlug(NoteSlug.create("gone"))).toBeUndefined();
+  });
+
+  it("deletes a note by id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const saved = await cmd.upsert(
+      unpersistedNote({ slug: "byid", title: "T" }),
+    );
+    await cmd.delete(saved.id);
+
+    expect(await query.findBySlug(NoteSlug.create("byid"))).toBeUndefined();
+  });
+});

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -1,0 +1,60 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteCommandRepository,
+  Note,
+  NoteId,
+  NoteSlug,
+} from "~/backend/domain/note";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { notes } from "~/backend/infra/d1/schema";
+import { instantToUnix, plainDateToIso } from "~/backend/infra/d1/temporal";
+
+export class D1NoteCommandRepository implements INoteCommandRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  /**
+   * slug をキーに upsert する。新規なら id と created_at を採番し、既存なら
+   * それらを保持したまま内容と updated_at を更新する。RETURNING で確定行を取り、
+   * 永続化済みエンティティを復元して返す。
+   */
+  async upsert(note: Note<IUnpersisted>): Promise<Note> {
+    const now = Temporal.Now.instant();
+    const nowUnix = instantToUnix(now);
+    const content = {
+      title: note.title.toString(),
+      summary: note.summary,
+      imageUrl: note.imageUrl?.toString() ?? null,
+      publishedOn: plainDateToIso(note.publishedOn),
+      lastModifiedOn: plainDateToIso(note.lastModifiedOn),
+      updatedAt: nowUnix,
+    };
+
+    const [row] = await this.db
+      .insert(notes)
+      .values({
+        id: crypto.randomUUID(),
+        slug: note.slug.toString(),
+        createdAt: nowUnix,
+        ...content,
+      })
+      .onConflictDoUpdate({ target: notes.slug, set: content })
+      .returning();
+
+    return rowToNote(row);
+  }
+
+  async deleteBySlug(slug: NoteSlug): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.slug, slug.toString()));
+  }
+
+  async delete(id: NoteId): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.id, id));
+  }
+}

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -1,0 +1,91 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function seed(params: {
+  slug: string;
+  publishedOn: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.slug),
+    summary: "s",
+    publishedOn: Temporal.PlainDate.from(params.publishedOn),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? params.publishedOn,
+    ),
+  });
+}
+
+async function seedNotes(cmd: D1NoteCommandRepository): Promise<void> {
+  await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-10" }));
+  await cmd.upsert(seed({ slug: "b", publishedOn: "2026-03-10" }));
+  await cmd.upsert(seed({ slug: "c", publishedOn: "2026-02-10" }));
+}
+
+describe("D1NoteQueryRepository", () => {
+  it("returns undefined for an unknown slug", async () => {
+    const query = new D1NoteQueryRepository(createTestD1());
+    expect(await query.findBySlug(NoteSlug.create("nope"))).toBeUndefined();
+  });
+
+  it("finds a note by slug after upsert", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      seed({ slug: "found", publishedOn: "2026-01-01" }),
+    );
+    const found = await new D1NoteQueryRepository(d1).findBySlug(
+      NoteSlug.create("found"),
+    );
+    expect(found?.slug.toString()).toBe("found");
+  });
+
+  it("orders by publishedOn descending by default sort field", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["b", "c", "a"]);
+  });
+
+  it("orders ascending when requested", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "asc",
+    });
+
+    expect(notes.map((n) => n.slug.toString())).toEqual(["a", "c", "b"]);
+  });
+
+  it("applies limit and offset for pagination while total stays the full count", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 1,
+      offset: 1,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
+});

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -88,4 +88,31 @@ describe("D1NoteQueryRepository", () => {
     expect(total).toBe(3);
     expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
   });
+
+  it("keeps a stable order across pages when dates tie (slug tiebreaker)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    // 全て同じ publishedOn。タイブレーカが無いと offset ページングで重複・欠落しうる。
+    await cmd.upsert(seed({ slug: "c", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "b", publishedOn: "2026-01-15" }));
+    const query = new D1NoteQueryRepository(d1);
+
+    const page1 = await query.list({
+      limit: 2,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    const page2 = await query.list({
+      limit: 2,
+      offset: 2,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    // slug 昇順で安定 → ページをまたいで a, b, c が重複なく並ぶ。
+    expect(page1.notes.map((n) => n.slug.toString())).toEqual(["a", "b"]);
+    expect(page2.notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -35,18 +35,21 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
 
   async list(query: NoteListQuery): Promise<NoteListResult> {
     const column = sortColumns[query.sortBy];
-    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+    const primary = query.direction === "asc" ? asc(column) : desc(column);
+    // 同じ日付のノート同士でも順序を安定させる決定的なタイブレーカ。slug は UNIQUE
+    // なので offset ページネーションで行の重複・欠落が起きない。
+    const tiebreaker = asc(notes.slug);
 
-    const rows = await this.db
-      .select()
-      .from(notes)
-      .orderBy(orderBy)
-      .limit(query.limit)
-      .offset(query.offset);
-
-    const [{ value: total }] = await this.db
-      .select({ value: count() })
-      .from(notes);
+    // 行取得と総件数取得は独立なので並行実行する (公開一覧のホットパスの往復を半減)。
+    const [rows, [{ value: total }]] = await Promise.all([
+      this.db
+        .select()
+        .from(notes)
+        .orderBy(primary, tiebreaker)
+        .limit(query.limit)
+        .offset(query.offset),
+      this.db.select({ value: count() }).from(notes),
+    ]);
 
     return { notes: rows.map((row) => rowToNote(row)), total };
   }

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -1,0 +1,53 @@
+import { asc, count, desc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteQueryRepository,
+  Note,
+  NoteListQuery,
+  NoteListResult,
+  NoteSlug,
+  NoteSortField,
+} from "~/backend/domain/note";
+import { notes } from "~/backend/infra/d1/schema";
+
+const sortColumns = {
+  publishedOn: notes.publishedOn,
+  lastModifiedOn: notes.lastModifiedOn,
+} as const satisfies Record<NoteSortField, unknown>;
+
+export class D1NoteQueryRepository implements INoteQueryRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  async findBySlug(slug: NoteSlug): Promise<Note | undefined> {
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .where(eq(notes.slug, slug.toString()))
+      .limit(1);
+    const row = rows.at(0);
+    return row === undefined ? undefined : rowToNote(row);
+  }
+
+  async list(query: NoteListQuery): Promise<NoteListResult> {
+    const column = sortColumns[query.sortBy];
+    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .orderBy(orderBy)
+      .limit(query.limit)
+      .offset(query.offset);
+
+    const [{ value: total }] = await this.db
+      .select({ value: count() })
+      .from(notes);
+
+    return { notes: rows.map((row) => rowToNote(row)), total };
+  }
+}

--- a/app/backend/infra/d1/schema/index.ts
+++ b/app/backend/infra/d1/schema/index.ts
@@ -1,1 +1,2 @@
+export { notes } from "./notes";
 export { users } from "./users";

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -1,0 +1,22 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * ノートのメタデータインデックス。コンテンツ正本は Cloudflare Artifacts、
+ * 本文 (MDAST) と画像は R2 にあり、この D1 テーブルは一覧・ルーティング用の
+ * メタデータだけを保持する (ADR 0005)。
+ *
+ * - published_on / last_modified_on: フロントマター由来の日付。ISO 日付文字列
+ *   ("YYYY-MM-DD") で保存し、辞書順ソート = 日付順ソートを利用する。
+ * - created_at / updated_at: D1 行の作成・更新時刻 (Unix 秒)。コンテンツ日付とは別。
+ */
+export const notes = sqliteTable("notes", {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull().unique(),
+  title: text("title").notNull(),
+  summary: text("summary").notNull(),
+  imageUrl: text("image_url"),
+  publishedOn: text("published_on").notNull(),
+  lastModifiedOn: text("last_modified_on").notNull(),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -13,3 +13,19 @@ export function instantToUnix(instant: Temporal.Instant): number {
 export function unixToInstant(unix: number): Temporal.Instant {
   return Temporal.Instant.fromEpochMilliseconds(unix * 1000);
 }
+
+/**
+ * Convert a Temporal.PlainDate to an ISO date string ("YYYY-MM-DD") for D1 text
+ * storage. ISO date strings sort lexicographically in the same order as the dates,
+ * so they can be ordered directly in SQL.
+ */
+export function plainDateToIso(date: Temporal.PlainDate): string {
+  return date.toString();
+}
+
+/**
+ * Convert an ISO date string ("YYYY-MM-DD") from D1 to a Temporal.PlainDate.
+ */
+export function isoToPlainDate(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -20,7 +20,10 @@ export function unixToInstant(unix: number): Temporal.Instant {
  * so they can be ordered directly in SQL.
  */
 export function plainDateToIso(date: Temporal.PlainDate): string {
-  return date.toString();
+  // calendarName: "never" で "[u-ca=...]" 注釈を落とし、常に "YYYY-MM-DD" にする。
+  // これを付けないと非 ISO カレンダーの PlainDate が注釈付き文字列になり、
+  // 往復とソートが壊れる。
+  return date.toString({ calendarName: "never" });
 }
 
 /**

--- a/app/frontend/components/pagination/build-page-items.test.ts
+++ b/app/frontend/components/pagination/build-page-items.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildPageItems } from "./build-page-items";
+
+describe("buildPageItems", () => {
+  it("lists every page without ellipsis when the range is small", () => {
+    expect(buildPageItems(2, 4)).toEqual([
+      { type: "page", page: 1 },
+      { type: "page", page: 2 },
+      { type: "page", page: 3 },
+      { type: "page", page: 4 },
+    ]);
+  });
+
+  it("inserts an ellipsis on the right when far from the end", () => {
+    expect(buildPageItems(2, 10)).toEqual([
+      { type: "page", page: 1 },
+      { type: "page", page: 2 },
+      { type: "page", page: 3 },
+      { type: "ellipsis", after: 3 },
+      { type: "page", page: 10 },
+    ]);
+  });
+
+  it("inserts ellipses on both sides in the middle", () => {
+    expect(buildPageItems(6, 12)).toEqual([
+      { type: "page", page: 1 },
+      { type: "ellipsis", after: 1 },
+      { type: "page", page: 5 },
+      { type: "page", page: 6 },
+      { type: "page", page: 7 },
+      { type: "ellipsis", after: 7 },
+      { type: "page", page: 12 },
+    ]);
+  });
+
+  it("gives ellipses distinct keys via their `after` page", () => {
+    const items = buildPageItems(6, 12).filter(
+      (item) => item.type === "ellipsis",
+    );
+    const keys = items.map((item) => item.after);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/app/frontend/components/pagination/build-page-items.ts
+++ b/app/frontend/components/pagination/build-page-items.ts
@@ -1,0 +1,29 @@
+/**
+ * ページ項目。ellipsis はどのページの後ろの隙間かを `after` に持たせ、
+ * React の key を安定・一意にする (配列 index を key に使わない)。
+ */
+export type PageItem =
+  | { readonly type: "page"; readonly page: number }
+  | { readonly type: "ellipsis"; readonly after: number };
+
+/**
+ * 表示するページ項目を組み立てる。先頭・末尾は常に出し、現在ページの前後 1 件を
+ * 窓として出す。間が空くところは省略記号を挟む。
+ */
+export function buildPageItems(page: number, totalPages: number): PageItem[] {
+  const wanted = new Set<number>([1, totalPages, page - 1, page, page + 1]);
+  const visible = [...wanted]
+    .filter((p) => p >= 1 && p <= totalPages)
+    .toSorted((a, b) => a - b);
+
+  const items: PageItem[] = [];
+  let previous = 0;
+  for (const p of visible) {
+    if (previous !== 0 && p - previous > 1) {
+      items.push({ type: "ellipsis", after: previous });
+    }
+    items.push({ type: "page", page: p });
+    previous = p;
+  }
+  return items;
+}

--- a/app/frontend/components/pagination/pagination.stories.tsx
+++ b/app/frontend/components/pagination/pagination.stories.tsx
@@ -1,0 +1,34 @@
+import { Pagination } from "./pagination";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof Pagination> = {
+  title: "Pagination/Pagination",
+  component: Pagination,
+  parameters: { layout: "centered" },
+  args: {
+    hrefForPage: (page: number) => `?page=${String(page)}`,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstPage: Story = {
+  args: { page: 1, totalPages: 5 },
+};
+
+export const MiddlePage: Story = {
+  args: { page: 3, totalPages: 5 },
+};
+
+export const LastPage: Story = {
+  args: { page: 10, totalPages: 10 },
+};
+
+export const ManyPagesWithEllipsis: Story = {
+  args: { page: 8, totalPages: 20 },
+};
+
+export const SinglePageRendersNothing: Story = {
+  args: { page: 1, totalPages: 1 },
+};

--- a/app/frontend/components/pagination/pagination.tsx
+++ b/app/frontend/components/pagination/pagination.tsx
@@ -1,0 +1,81 @@
+import { Link } from "@inertiajs/react";
+import { useTranslation } from "react-i18next";
+import { buildPageItems } from "./build-page-items";
+
+export interface PaginationProps {
+  /** 現在のページ (1 始まり)。 */
+  readonly page: number;
+  /** 総ページ数。 */
+  readonly totalPages: number;
+  /** ページ番号から遷移先 URL を組み立てる。 */
+  readonly hrefForPage: (page: number) => string;
+}
+
+/** ページネーション UI。総ページ数が 1 以下のときは何も描画しない。 */
+export function Pagination({
+  page,
+  totalPages,
+  hrefForPage,
+}: PaginationProps): React.JSX.Element | null {
+  const { t } = useTranslation();
+  if (totalPages <= 1) return null;
+
+  const items = buildPageItems(page, totalPages);
+  const hasPrev = page > 1;
+  const hasNext = page < totalPages;
+
+  return (
+    <nav className="join" aria-label={t("notes.pagination.label")}>
+      {hasPrev ? (
+        <Link
+          href={hrefForPage(page - 1)}
+          rel="prev"
+          className="join-item btn"
+          aria-label={t("notes.pagination.previous")}
+        >
+          «
+        </Link>
+      ) : (
+        <span className="join-item btn btn-disabled" aria-hidden="true">
+          «
+        </span>
+      )}
+
+      {items.map((item) =>
+        item.type === "ellipsis" ? (
+          <span
+            key={`ellipsis-after-${String(item.after)}`}
+            className="join-item btn btn-disabled"
+            aria-hidden="true"
+          >
+            …
+          </span>
+        ) : (
+          <Link
+            key={item.page}
+            href={hrefForPage(item.page)}
+            className={`join-item btn${item.page === page ? " btn-active" : ""}`}
+            aria-current={item.page === page ? "page" : undefined}
+          >
+            {item.page}
+          </Link>
+        ),
+      )}
+
+      {hasNext ? (
+        <Link
+          href={hrefForPage(page + 1)}
+          rel="next"
+          className="join-item btn"
+          aria-label={t("notes.pagination.next")}
+        >
+          »
+        </Link>
+      ) : (
+        <span className="join-item btn btn-disabled" aria-hidden="true">
+          »
+        </span>
+      )}
+    </nav>
+  );
+}

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,4 +1,4 @@
-import { Head, router } from "@inertiajs/react";
+import { Head, Link, router } from "@inertiajs/react";
 import { useTranslation } from "react-i18next";
 import type { PageProps } from "~/frontend/page-props";
 import { AppLayout } from "~/frontend/layouts/app-layout";
@@ -23,15 +23,20 @@ export default function Home({ user }: HomeProps): React.JSX.Element {
             {t("home.welcome", { name: user.displayName })}
           </h1>
           <p className="mt-4 text-base-content/60">{user.email}</p>
-          <button
-            type="button"
-            className="btn btn-primary mt-8"
-            onClick={() => {
-              router.post("/auth/logout");
-            }}
-          >
-            {t("home.logout")}
-          </button>
+          <div className="mt-8 flex items-center justify-center gap-4">
+            <Link href="/notes" className="btn btn-primary">
+              {t("home.viewNotes")}
+            </Link>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => {
+                router.post("/auth/logout");
+              }}
+            >
+              {t("home.logout")}
+            </button>
+          </div>
         </div>
       </main>
     </AppLayout>

--- a/app/frontend/pages/notes/index.tsx
+++ b/app/frontend/pages/notes/index.tsx
@@ -22,17 +22,40 @@ interface NotesIndexProps extends PageProps {
     readonly total: number;
     readonly totalPages: number;
   };
+  readonly sort: {
+    readonly sortBy: string | null;
+    readonly order: string | null;
+  };
 }
 
-function hrefForPage(page: number): string {
-  return page <= 1 ? "/notes" : `/notes?page=${String(page)}`;
+const DEFAULT_PER_PAGE = 20;
+
+/**
+ * ページ送りリンクの URL を組み立てる。現在の per-page / sort-by / order を保持し、
+ * 既定値は省略して URL をきれいに保つ。
+ */
+function buildHrefForPage(
+  page: number,
+  perPage: number,
+  sort: NotesIndexProps["sort"],
+): string {
+  const params = new URLSearchParams();
+  if (page > 1) params.set("page", String(page));
+  if (perPage !== DEFAULT_PER_PAGE) params.set("per-page", String(perPage));
+  if (sort.sortBy !== null) params.set("sort-by", sort.sortBy);
+  if (sort.order !== null) params.set("order", sort.order);
+  const query = params.toString();
+  return query.length > 0 ? `/notes?${query}` : "/notes";
 }
 
 export default function NotesIndex({
   notes,
   pagination,
+  sort,
 }: NotesIndexProps): React.JSX.Element {
   const { t } = useTranslation();
+  const hrefForPage = (page: number): string =>
+    buildHrefForPage(page, pagination.perPage, sort);
 
   return (
     <AppLayout>

--- a/app/frontend/pages/notes/index.tsx
+++ b/app/frontend/pages/notes/index.tsx
@@ -1,0 +1,93 @@
+import { Head, Link } from "@inertiajs/react";
+import { useTranslation } from "react-i18next";
+import type { PageProps } from "~/frontend/page-props";
+import { Header } from "~/frontend/components/layout/header";
+import { Pagination } from "~/frontend/components/pagination/pagination";
+import { AppLayout } from "~/frontend/layouts/app-layout";
+
+interface PublicNote {
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly imageUrl: string | null;
+  readonly publishedOn: string;
+  readonly lastModifiedOn: string;
+}
+
+interface NotesIndexProps extends PageProps {
+  readonly notes: readonly PublicNote[];
+  readonly pagination: {
+    readonly page: number;
+    readonly perPage: number;
+    readonly total: number;
+    readonly totalPages: number;
+  };
+}
+
+function hrefForPage(page: number): string {
+  return page <= 1 ? "/notes" : `/notes?page=${String(page)}`;
+}
+
+export default function NotesIndex({
+  notes,
+  pagination,
+}: NotesIndexProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <AppLayout>
+      <Head title={t("notes.title")} />
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-10">
+        <h1 className="text-3xl font-bold">{t("notes.heading")}</h1>
+
+        {notes.length === 0 ? (
+          <p className="mt-8 text-base-content/60">{t("notes.empty")}</p>
+        ) : (
+          <ul className="mt-8 flex flex-col gap-4">
+            {notes.map((note) => (
+              <li key={note.slug}>
+                <Link
+                  href={`/notes/${note.slug}`}
+                  className="card card-side bg-base-200 shadow-sm transition-shadow hover:shadow-md"
+                >
+                  {note.imageUrl !== null && (
+                    <figure className="w-32 shrink-0">
+                      <img
+                        src={note.imageUrl}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        className="h-full w-full object-cover"
+                      />
+                    </figure>
+                  )}
+                  <div className="card-body">
+                    <h2 className="card-title">{note.title}</h2>
+                    <time
+                      dateTime={note.publishedOn}
+                      className="text-sm text-base-content/60"
+                    >
+                      {note.publishedOn}
+                    </time>
+                    <p className="line-clamp-2 text-base-content/80">
+                      {note.summary}
+                    </p>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="mt-10 flex justify-center">
+          <Pagination
+            page={pagination.page}
+            totalPages={pagination.totalPages}
+            hrefForPage={hrefForPage}
+          />
+        </div>
+      </main>
+    </AppLayout>
+  );
+}

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -6,7 +6,18 @@
   "home": {
     "heading": "yantene",
     "welcome": "Welcome, {{name}}",
+    "viewNotes": "View notes",
     "logout": "Log out"
+  },
+  "notes": {
+    "title": "Notes",
+    "heading": "Notes",
+    "empty": "No notes have been published yet.",
+    "pagination": {
+      "label": "Pagination",
+      "previous": "Previous page",
+      "next": "Next page"
+    }
   },
   "login": {
     "heading": "Sign in",

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -6,7 +6,18 @@
   "home": {
     "heading": "yantene",
     "welcome": "ようこそ、{{name}} さん",
+    "viewNotes": "ノートを見る",
     "logout": "ログアウト"
+  },
+  "notes": {
+    "title": "ノート",
+    "heading": "ノート",
+    "empty": "まだ公開されたノートがない。",
+    "pagination": {
+      "label": "ページ送り",
+      "previous": "前のページ",
+      "next": "次のページ"
+    }
   },
   "login": {
     "heading": "ログイン",

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,11 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                               | Status   |
-| ------------------------------------------------------ | ------------------------------------------------------ | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する           | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する          | Accepted |
+| #                                                      | タイトル                                                   | Status   |
+| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
 | [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |

--- a/migrations/0001_create_notes_table.sql
+++ b/migrations/0001_create_notes_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `notes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`title` text NOT NULL,
+	`summary` text NOT NULL,
+	`image_url` text,
+	`published_on` text NOT NULL,
+	`last_modified_on` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `notes_slug_unique` ON `notes` (`slug`);

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,148 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "515262b0-5233-4003-a022-dfa0039ad1e7",
+  "prevId": "02defeaf-eeb8-4612-9ac8-b1965a1d4bea",
+  "tables": {
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780567722357,
       "tag": "0000_create_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1783215054973,
+      "tag": "0001_create_notes_table",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Closes #8 / depends on #5 (PR #14)

ノート一覧の公開 JSON API と Inertia ページ。クローラー・ボット対応のため認証不要。

> ℹ️ #14 (issue-5) → #13 (issue-4) にスタックしています。親 PR マージ後に差分は本 PR 分になります。

## やったこと

- **`GET /api/v1/notes`** — `page` / `per-page` / `sort-by` (published|modified) / `order` (asc|desc)。kebab-case クエリ、安全側クランプ
- **公開ページ `/notes`** (`pages/notes/index.tsx`) + トップページからの導線
- **Pagination コンポーネント** — 先頭/末尾 + 現在ページ窓 + 省略記号。`buildPageItems` を純関数に分離して単体テスト。ellipsis の key は `after` で安定化
- **PublicNote DTO** (`note-view`) — 公開フィールドのみ (id 非公開)、`imageUrl` は null 許容
- **SSR** — locale + inertia ミドルウェア配下で描画
- **公開/保護ルーティングの合成テスト** — 実アプリ合成で `/api/v1/notes` が公開・`/api/me` が 401 のままを検証

## 設計判断

- 公開ノート API/ページは `requireSession` / `requireSessionOrRedirect` ガードより**前**にマウントし、ハンドラが応答して短絡することで認証を通さない。既存の保護 API (`/api/me`) は不変。

## CI について

⚠️ `deploy-preview` は Cloudflare Secrets 未設定により失敗 (環境要因)。他は全て pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S