### PR TITLE
feat(infra): Artifacts 接続基盤と R2 バインディングを構築する

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -1,7 +1,7 @@
 # 環境構成
 
-| 環境        | トリガー          | DB                                         |
-| ----------- | ----------------- | ------------------------------------------ |
+| 環境        | トリガー          | DB                          |
+| ----------- | ----------------- | --------------------------- |
 | development | ローカル          | yantene-development (local) |
 | staging     | PR / push to main | yantene-staging             |
 | production  | GitHub Release    | yantene-production          |

--- a/.claude/rules/product.md
+++ b/.claude/rules/product.md
@@ -51,7 +51,7 @@ NoteTitle / ImageUrl 等の VO に変換する。
 ```yaml
 ---
 title: 記事タイトル
-imageUrl: ./cover.png       # 相対パス → アセット API URL に解決される
+imageUrl: ./cover.png # 相対パス → アセット API URL に解決される
 publishedOn: 2026-01-15
 lastModifiedOn: 2026-01-20
 ---

--- a/app/backend/domain/content/content-store.interface.ts
+++ b/app/backend/domain/content/content-store.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * コンテンツ正本 (Markdown 本文・画像アセット) の読み取り口。
+ * ドメインはストレージ技術 (Cloudflare Artifacts 等) を知らない。infra が実装する。
+ *
+ * 変更検出はコンテンツハッシュで行う: refresh 時にツリーを取得し、各ファイルの
+ * ハッシュを D1 の保存済みと比較して、変わったファイルだけ読み直す (ADR 0005)。
+ */
+
+/** ツリー内の 1 ファイル。hash はそのファイル内容のリビジョン識別子。 */
+export interface ContentEntry {
+  /** 正本内のパス (例: "notes/my-note.md", "notes/my-note/cover.png")。 */
+  readonly path: string;
+  /** ファイル内容のハッシュ (変更検出用)。 */
+  readonly hash: string;
+}
+
+export interface IContentStore {
+  /** 全ファイルのパスとハッシュを列挙する (変更検出のためのスナップショット)。 */
+  listTree(): Promise<readonly ContentEntry[]>;
+
+  /**
+   * パス指定でファイルの生バイト列を読む。存在しなければ undefined を返す。
+   */
+  readFile(path: string): Promise<Uint8Array | undefined>;
+}

--- a/app/backend/domain/content/index.ts
+++ b/app/backend/domain/content/index.ts
@@ -1,0 +1,1 @@
+export type { ContentEntry, IContentStore } from "./content-store.interface";

--- a/app/backend/domain/note/errors.ts
+++ b/app/backend/domain/note/errors.ts
@@ -1,0 +1,6 @@
+export class NoteNotFoundError extends Error {
+  readonly name = "NoteNotFoundError";
+  constructor(slug: string) {
+    super(`Note not found: ${slug}`);
+  }
+}

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+
+describe("ImageUrl", () => {
+  it("accepts a root-relative asset API path", () => {
+    const url = "/api/v1/notes/my-note/assets/cover.png";
+    expect(ImageUrl.create(url).toString()).toBe(url);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(ImageUrl.create("  /a/b.png  ").toString()).toBe("/a/b.png");
+  });
+
+  it("rejects unresolved relative paths", () => {
+    expect(() => ImageUrl.create("./cover.png")).toThrow(InvalidImageUrlError);
+    expect(() => ImageUrl.create("cover.png")).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects absolute URLs, including raw Artifacts URLs", () => {
+    // 絶対 URL は Artifacts の直接 URL 露出につながり、CSP (img-src 'self') でも
+    // 表示できないため弾く。
+    expect(() => ImageUrl.create("https://example.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() =>
+      ImageUrl.create("https://artifacts.example/raw/notes/x/cover.png"),
+    ).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects protocol-relative and non-http schemes", () => {
+    expect(() => ImageUrl.create("//evil.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("javascript:alert(1)")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("data:image/png;base64,AAAA")).toThrow(
+      InvalidImageUrlError,
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => ImageUrl.create(" ".repeat(3))).toThrow(InvalidImageUrlError);
+  });
+
+  it("compares by value with equals", () => {
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/a.png"))).toBe(
+      true,
+    );
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/b.png"))).toBe(
+      false,
+    );
+  });
+});

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -1,0 +1,48 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// ノートのカバー画像 URL。フロントマターの相対パス (`./cover.png`) は
+// アセット API URL (ルート相対 `/api/v1/notes/<slug>/assets/...`) に解決してから
+// VO 化する前提で、ここでは解決済みの「ルート相対パス」だけを受け入れる。
+//
+// 絶対 URL は弾く。これは 2 つの規約を同時に満たすため:
+//   - Artifacts の直接 URL を露出させない (product 規約)。絶対 URL を許すと
+//     未解決の生 Artifacts URL がそのまま通り得る。
+//   - 画像はアセット API (self) 経由で配信する。CSP の img-src は 'self' data:
+//     のみで外部ホストの画像は表示できないため、絶対 URL を持たせても無意味。
+const MAX_LENGTH = 2048;
+
+export class InvalidImageUrlError extends Error {
+  readonly name = "InvalidImageUrlError";
+}
+
+export class ImageUrl implements IValueObject<ImageUrl> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): ImageUrl {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidImageUrlError(
+        `Image URL must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    // ルート相対パスのみ。"//" 始まり (プロトコル相対 = 絶対 URL 相当) は弾く。
+    if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+      throw new InvalidImageUrlError(
+        "Image URL must be a root-relative asset path (e.g. /api/v1/notes/<slug>/assets/<file>)",
+      );
+    }
+    return new ImageUrl(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: ImageUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -1,0 +1,14 @@
+export { NoteNotFoundError } from "./errors";
+export { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+export { Note } from "./note.entity";
+export type { NoteId } from "./note.entity";
+export type { INoteCommandRepository } from "./note.command-repository.interface";
+export type {
+  INoteQueryRepository,
+  NoteListQuery,
+  NoteListResult,
+  NoteSortField,
+  SortDirection,
+} from "./note.query-repository.interface";

--- a/app/backend/domain/note/note-slug.vo.test.ts
+++ b/app/backend/domain/note/note-slug.vo.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+
+describe("NoteSlug", () => {
+  it("accepts lowercase alphanumerics with single hyphens", () => {
+    expect(NoteSlug.create("hello-world-2026").toString()).toBe(
+      "hello-world-2026",
+    );
+  });
+
+  it("trims and lowercases input", () => {
+    expect(NoteSlug.create("  Hello-World  ").toString()).toBe("hello-world");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => NoteSlug.create(" ".repeat(3))).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects leading, trailing, and doubled hyphens", () => {
+    expect(() => NoteSlug.create("-hello")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello-")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello--world")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects characters outside [a-z0-9-]", () => {
+    expect(() => NoteSlug.create("hello_world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("こんにちは")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects slugs longer than 200 characters", () => {
+    expect(() => NoteSlug.create("a".repeat(201))).toThrow(
+      InvalidNoteSlugError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("foo"))).toBe(true);
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("bar"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteSlug.create("foo-bar").toJSON()).toBe("foo-bar");
+  });
+});

--- a/app/backend/domain/note/note-slug.vo.ts
+++ b/app/backend/domain/note/note-slug.vo.ts
@@ -1,0 +1,47 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// スラグは URL パスセグメントに乗る識別子。小文字英数字とハイフンのみ許可する。
+// ハイフンの位置制約 (先頭・末尾・連続の禁止) はネストした量指定子の正規表現で
+// まとめて表現すると ReDoS 検知に触れるため、単純な文字クラス検査 + 個別チェックに分ける。
+const slugCharsPattern = /^[a-z0-9-]+$/;
+const MAX_LENGTH = 200;
+
+export class InvalidNoteSlugError extends Error {
+  readonly name = "InvalidNoteSlugError";
+}
+
+export class NoteSlug implements IValueObject<NoteSlug> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteSlug {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteSlugError(
+        `Note slug must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    if (
+      !slugCharsPattern.test(trimmed) ||
+      trimmed.startsWith("-") ||
+      trimmed.endsWith("-") ||
+      trimmed.includes("--")
+    ) {
+      throw new InvalidNoteSlugError(
+        "Note slug must be lowercase alphanumerics separated by single hyphens",
+      );
+    }
+    return new NoteSlug(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteSlug): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note-title.vo.test.ts
+++ b/app/backend/domain/note/note-title.vo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+
+describe("NoteTitle", () => {
+  it("keeps the original casing and symbols", () => {
+    expect(NoteTitle.create("Hello, World! 記事").toString()).toBe(
+      "Hello, World! 記事",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(NoteTitle.create("  Title  ").toString()).toBe("Title");
+  });
+
+  it("rejects empty or whitespace-only input", () => {
+    expect(() => NoteTitle.create("")).toThrow(InvalidNoteTitleError);
+    expect(() => NoteTitle.create(" ".repeat(3))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("rejects titles longer than 200 characters", () => {
+    expect(() => NoteTitle.create("あ".repeat(201))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteTitle.create("A").equals(NoteTitle.create("A"))).toBe(true);
+    expect(NoteTitle.create("A").equals(NoteTitle.create("B"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteTitle.create("Title").toJSON()).toBe("Title");
+  });
+});

--- a/app/backend/domain/note/note-title.vo.ts
+++ b/app/backend/domain/note/note-title.vo.ts
@@ -1,0 +1,35 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// タイトルはフロントマター由来の表示文字列。大文字小文字・記号はそのまま保つが、
+// 前後の空白は正規化し、空文字と過長を弾く。
+const MAX_LENGTH = 200;
+
+export class InvalidNoteTitleError extends Error {
+  readonly name = "InvalidNoteTitleError";
+}
+
+export class NoteTitle implements IValueObject<NoteTitle> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteTitle {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteTitleError(
+        `Note title must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    return new NoteTitle(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteTitle): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note.command-repository.interface.ts
+++ b/app/backend/domain/note/note.command-repository.interface.ts
@@ -1,0 +1,18 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note, NoteId } from "./note.entity";
+import type { IUnpersisted } from "~/backend/domain/shared";
+
+export interface INoteCommandRepository {
+  /**
+   * ノートのメタデータを slug をキーに upsert する。
+   * refresh 時に Artifacts の内容で D1 を同期するための操作。
+   * 既存 slug があれば更新、無ければ新規作成し、永続化済みエンティティを返す。
+   */
+  upsert(note: Note<IUnpersisted>): Promise<Note>;
+
+  /** slug のノートを削除する (Artifacts から消えたノートの掃除に使う)。 */
+  deleteBySlug(slug: NoteSlug): Promise<void>;
+
+  /** id のノートを削除する。 */
+  delete(id: NoteId): Promise<void>;
+}

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -1,0 +1,71 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { ImageUrl } from "./image-url.vo";
+import { NoteSlug } from "./note-slug.vo";
+import { NoteTitle } from "./note-title.vo";
+import { Note } from "./note.entity";
+import { entityId } from "~/backend/domain/shared";
+
+const slug = NoteSlug.create("my-note");
+const title = NoteTitle.create("My Note");
+const publishedOn = Temporal.PlainDate.from("2026-01-15");
+const lastModifiedOn = Temporal.PlainDate.from("2026-01-20");
+
+describe("Note.create", () => {
+  it("builds an unpersisted note with undefined id and timestamps", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "A short summary.",
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.id).toBeUndefined();
+    expect(note.createdAt).toBeUndefined();
+    expect(note.updatedAt).toBeUndefined();
+    expect(note.slug.toString()).toBe("my-note");
+    expect(note.title.toString()).toBe("My Note");
+    expect(note.summary).toBe("A short summary.");
+    expect(note.imageUrl).toBeUndefined();
+    expect(note.publishedOn.toString()).toBe("2026-01-15");
+    expect(note.lastModifiedOn.toString()).toBe("2026-01-20");
+  });
+
+  it("retains an optional cover image", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "s",
+      imageUrl: ImageUrl.create("/api/v1/notes/my-note/assets/cover.png"),
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.imageUrl?.toString()).toBe(
+      "/api/v1/notes/my-note/assets/cover.png",
+    );
+  });
+});
+
+describe("Note.reconstruct", () => {
+  it("restores a persisted note with id and timestamps", () => {
+    const createdAt = Temporal.Instant.from("2026-01-15T00:00:00Z");
+    const updatedAt = Temporal.Instant.from("2026-01-20T00:00:00Z");
+    const note = Note.reconstruct({
+      id: entityId<"Note">("note-1"),
+      slug,
+      title,
+      summary: "s",
+      imageUrl: undefined,
+      publishedOn,
+      lastModifiedOn,
+      createdAt,
+      updatedAt,
+    });
+
+    expect(note.id).toBe("note-1");
+    expect(note.createdAt.equals(createdAt)).toBe(true);
+    expect(note.updatedAt.equals(updatedAt)).toBe(true);
+  });
+});

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -1,0 +1,108 @@
+import type { ImageUrl } from "./image-url.vo";
+import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTitle } from "./note-title.vo";
+import type { Temporal } from "@js-temporal/polyfill";
+import type {
+  EntityId,
+  IPersisted,
+  IUnpersisted,
+} from "~/backend/domain/shared";
+
+export type NoteId = EntityId<"Note">;
+
+interface NoteFields<T extends IPersisted | IUnpersisted> {
+  readonly id: T["id"] extends string ? NoteId : undefined;
+  readonly slug: NoteSlug;
+  readonly title: NoteTitle;
+  /** MDAST から自動抽出した一覧用の要約 (先頭 160 文字)。手書きしない。 */
+  readonly summary: string;
+  /** カバー画像 URL。フロントマターに imageUrl が無ければ undefined。 */
+  readonly imageUrl: ImageUrl | undefined;
+  /** フロントマター由来の公開日 (日付のみ)。 */
+  readonly publishedOn: Temporal.PlainDate;
+  /** フロントマター由来の最終更新日 (日付のみ)。 */
+  readonly lastModifiedOn: Temporal.PlainDate;
+  /** D1 行の作成・更新時刻 (永続化メタデータ。コンテンツ日付とは別)。 */
+  readonly createdAt: T["createdAt"];
+  readonly updatedAt: T["updatedAt"];
+}
+
+/**
+ * ノート集約。Markdown 記事のメタデータを表す。
+ * 本文 (MDAST) と画像アセットは別ストレージ (R2) にあり、本エンティティは
+ * D1 のメタデータインデックスに対応する。
+ */
+export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
+  private constructor(private readonly fields: NoteFields<T>) {}
+
+  static create(params: {
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl?: ImageUrl;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+  }): Note<IUnpersisted> {
+    return new Note({
+      id: undefined,
+      slug: params.slug,
+      title: params.title,
+      summary: params.summary,
+      imageUrl: params.imageUrl,
+      publishedOn: params.publishedOn,
+      lastModifiedOn: params.lastModifiedOn,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  }
+
+  static reconstruct(params: {
+    id: NoteId;
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl: ImageUrl | undefined;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+    createdAt: Temporal.Instant;
+    updatedAt: Temporal.Instant;
+  }): Note {
+    return new Note(params);
+  }
+
+  get id(): NoteFields<T>["id"] {
+    return this.fields.id;
+  }
+
+  get slug(): NoteSlug {
+    return this.fields.slug;
+  }
+
+  get title(): NoteTitle {
+    return this.fields.title;
+  }
+
+  get summary(): string {
+    return this.fields.summary;
+  }
+
+  get imageUrl(): ImageUrl | undefined {
+    return this.fields.imageUrl;
+  }
+
+  get publishedOn(): Temporal.PlainDate {
+    return this.fields.publishedOn;
+  }
+
+  get lastModifiedOn(): Temporal.PlainDate {
+    return this.fields.lastModifiedOn;
+  }
+
+  get createdAt(): NoteFields<T>["createdAt"] {
+    return this.fields.createdAt;
+  }
+
+  get updatedAt(): NoteFields<T>["updatedAt"] {
+    return this.fields.updatedAt;
+  }
+}

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -1,0 +1,29 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note } from "./note.entity";
+
+/** 一覧の並び替え基準。 */
+export type NoteSortField = "publishedOn" | "lastModifiedOn";
+
+/** 並び順。 */
+export type SortDirection = "asc" | "desc";
+
+/** ページネーション + ソートのクエリ条件。 */
+export interface NoteListQuery {
+  /** 取得件数の上限 (1 以上)。 */
+  readonly limit: number;
+  /** スキップ件数 (0 以上)。 */
+  readonly offset: number;
+  readonly sortBy: NoteSortField;
+  readonly direction: SortDirection;
+}
+
+/** 一覧の取得結果。total は絞り込み前の全件数 (ページネーション用)。 */
+export interface NoteListResult {
+  readonly notes: readonly Note[];
+  readonly total: number;
+}
+
+export interface INoteQueryRepository {
+  findBySlug(slug: NoteSlug): Promise<Note | undefined>;
+  list(query: NoteListQuery): Promise<NoteListResult>;
+}

--- a/app/backend/handlers/notes/resolve-content-store.ts
+++ b/app/backend/handlers/notes/resolve-content-store.ts
@@ -1,0 +1,34 @@
+import type { IContentStore } from "~/backend/domain/content";
+import { ArtifactsContentStore } from "~/backend/infra/artifacts/artifacts-content-store";
+
+/**
+ * Composition Root: env から Artifacts の設定を解決して {@link IContentStore} を生成する。
+ *
+ * - namespace / repo / branch は wrangler.jsonc の vars。
+ * - accountId は secret (`wrangler secret put ARTIFACTS_ACCOUNT_ID`)。未設定なら
+ *   静かにフォールバックせず fail-loud で throw する (secure by default)。
+ * - read トークンは Artifacts binding でリポジトリスコープに発行し、Bearer に載せる。
+ */
+export function resolveContentStore(env: Env): IContentStore {
+  const accountId = (env as unknown as { ARTIFACTS_ACCOUNT_ID?: unknown })
+    .ARTIFACTS_ACCOUNT_ID;
+  if (typeof accountId !== "string" || accountId.length === 0) {
+    throw new Error(
+      "ARTIFACTS_ACCOUNT_ID is required to read content from Artifacts.",
+    );
+  }
+
+  const repo = env.ARTIFACTS_REPO;
+
+  return new ArtifactsContentStore({
+    accountId,
+    namespace: env.ARTIFACTS_NAMESPACE,
+    repo,
+    branch: env.ARTIFACTS_BRANCH,
+    getAuthToken: async () => {
+      const handle = await env.ARTIFACTS.get(repo);
+      const token = await handle.createToken("read");
+      return token.plaintext;
+    },
+  });
+}

--- a/app/backend/infra/artifacts/artifacts-content-store.test.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.test.ts
@@ -46,12 +46,25 @@ describe("parseTreeResponse", () => {
     ]);
   });
 
-  it("ignores malformed entries and non-objects", () => {
-    // null / 数値 / hash 欠落エントリはすべて落ちる。
+  it("ignores malformed entries within a recognized tree", () => {
+    // null / 数値 / hash 欠落エントリはすべて落ちる (形自体は認識できる)。
     expect(
       parseTreeResponse({ result: { tree: [null, 1, { path: "z" }] } }),
     ).toEqual([]);
-    expect(parseTreeResponse("nope")).toEqual([]);
+  });
+
+  it("returns [] for a legitimately empty tree", () => {
+    expect(parseTreeResponse({ result: { tree: [] } })).toEqual([]);
+    expect(parseTreeResponse([])).toEqual([]);
+  });
+
+  it("throws (fail-loud) on unrecognized shapes and error envelopes", () => {
+    // 認識できない形で [] にフォールバックすると全ノート削除と誤認されるため throw。
+    expect(() => parseTreeResponse("nope")).toThrow(ArtifactsRequestError);
+    expect(() => parseTreeResponse({ foo: 1 })).toThrow(ArtifactsRequestError);
+    expect(() =>
+      parseTreeResponse({ success: false, errors: [{ code: 1 }] }),
+    ).toThrow(ArtifactsRequestError);
   });
 });
 
@@ -106,5 +119,27 @@ describe("ArtifactsContentStore", () => {
     await expect(store(fetchFn).listTree()).rejects.toBeInstanceOf(
       ArtifactsRequestError,
     );
+  });
+
+  it("mints the auth token once and reuses it across operations", async () => {
+    const getAuthToken = vi.fn(() => Promise.resolve("tok-123"));
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(Response.json({ result: { tree: [] } })),
+    ) as unknown as typeof fetch;
+    const contentStore = new ArtifactsContentStore({
+      accountId: "acct-1",
+      namespace: "yantene",
+      repo: "notes",
+      branch: "main",
+      baseUrl: "https://api.test/client/v4",
+      getAuthToken,
+      fetchFn,
+    });
+
+    await contentStore.listTree();
+    await contentStore.readFile("a.md");
+    await contentStore.listTree();
+
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/backend/infra/artifacts/artifacts-content-store.test.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ArtifactsContentStore,
+  ArtifactsRequestError,
+  parseTreeResponse,
+} from "./artifacts-content-store";
+
+function store(fetchFn: typeof fetch): ArtifactsContentStore {
+  return new ArtifactsContentStore({
+    accountId: "acct-1",
+    namespace: "yantene",
+    repo: "notes",
+    branch: "main",
+    baseUrl: "https://api.test/client/v4",
+    getAuthToken: () => Promise.resolve("tok-123"),
+    fetchFn,
+  });
+}
+
+describe("parseTreeResponse", () => {
+  it("keeps blob entries and drops directories", () => {
+    const json = {
+      result: {
+        tree: [
+          { path: "notes/a.md", type: "blob", oid: "h1" },
+          { path: "notes", type: "tree", oid: "h2" },
+          { path: "notes/a/cover.png", type: "blob", oid: "h3" },
+        ],
+      },
+    };
+    expect(parseTreeResponse(json)).toEqual([
+      { path: "notes/a.md", hash: "h1" },
+      { path: "notes/a/cover.png", hash: "h3" },
+    ]);
+  });
+
+  it("accepts sha or hash as the hash field and a bare array", () => {
+    expect(
+      parseTreeResponse([
+        { path: "x.md", sha: "s1" },
+        { path: "y.md", hash: "s2" },
+      ]),
+    ).toEqual([
+      { path: "x.md", hash: "s1" },
+      { path: "y.md", hash: "s2" },
+    ]);
+  });
+
+  it("ignores malformed entries and non-objects", () => {
+    // null / 数値 / hash 欠落エントリはすべて落ちる。
+    expect(
+      parseTreeResponse({ result: { tree: [null, 1, { path: "z" }] } }),
+    ).toEqual([]);
+    expect(parseTreeResponse("nope")).toEqual([]);
+  });
+});
+
+describe("ArtifactsContentStore", () => {
+  it("lists the tree with a Bearer token from getAuthToken", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(
+        Response.json({ result: { tree: [{ path: "a.md", oid: "h1" }] } }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const entries = await store(fetchFn).listTree();
+    expect(entries).toEqual([{ path: "a.md", hash: "h1" }]);
+
+    const [url, init] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://api.test/client/v4/accounts/acct-1/artifacts/namespaces/yantene/repos/notes/tree/main",
+    );
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer tok-123",
+    });
+  });
+
+  it("reads a file's bytes by path", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response(bytes)),
+    ) as unknown as typeof fetch;
+
+    const result = await store(fetchFn).readFile("notes/a.md");
+    expect(result).toEqual(bytes);
+
+    const [url] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://api.test/client/v4/accounts/acct-1/artifacts/namespaces/yantene/repos/notes/file?ref=main&path=notes%2Fa.md",
+    );
+  });
+
+  it("returns undefined when a file is missing (404)", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response("not found", { status: 404 })),
+    ) as unknown as typeof fetch;
+    expect(await store(fetchFn).readFile("missing.md")).toBeUndefined();
+  });
+
+  it("throws ArtifactsRequestError on other non-ok responses", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response("boom", { status: 500 })),
+    ) as unknown as typeof fetch;
+    await expect(store(fetchFn).listTree()).rejects.toBeInstanceOf(
+      ArtifactsRequestError,
+    );
+  });
+});

--- a/app/backend/infra/artifacts/artifacts-content-store.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.ts
@@ -1,0 +1,145 @@
+import type { ContentEntry, IContentStore } from "~/backend/domain/content";
+
+const DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4";
+const HTTP_NOT_FOUND = 404;
+
+export interface ArtifactsContentStoreConfig {
+  /** Cloudflare アカウント ID。 */
+  readonly accountId: string;
+  /** Artifacts の namespace。 */
+  readonly namespace: string;
+  /** リポジトリ名。 */
+  readonly repo: string;
+  /** 読み取り対象のブランチ (既定 "main")。 */
+  readonly branch?: string;
+  /** REST API のベース URL (テスト差し替え用)。 */
+  readonly baseUrl?: string;
+  /**
+   * Bearer 認証トークンを取得する。Composition Root では Artifacts binding で
+   * リポジトリスコープの read トークンを発行して渡す想定。
+   */
+  readonly getAuthToken: () => Promise<string>;
+  /** fetch 実装 (テスト差し替え用)。 */
+  readonly fetchFn?: typeof fetch;
+}
+
+export class ArtifactsRequestError extends Error {
+  readonly name = "ArtifactsRequestError";
+  constructor(
+    readonly status: number,
+    detail: string,
+  ) {
+    super(`Artifacts request failed (${String(status)}): ${detail}`);
+  }
+}
+
+/**
+ * Cloudflare Artifacts の REST API を用いた {@link IContentStore} 実装。
+ *
+ * Artifacts の Workers binding はファイル読み取りを提供しない (repo 管理 + トークン
+ * 発行のみ) ため、binding で発行した read トークンを Bearer に載せて REST API を叩く
+ * (ADR 0005 / 0007)。
+ *
+ * ⚠️ tree エンドポイントのレスポンス JSON 形状は beta のため実 API で要確認。
+ * 解析は {@link parseTreeResponse} に隔離してあり、形状が違えばそこだけ直せばよい。
+ */
+export class ArtifactsContentStore implements IContentStore {
+  private readonly branch: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(private readonly config: ArtifactsContentStoreConfig) {
+    this.branch = config.branch ?? "main";
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.fetchFn = config.fetchFn ?? fetch;
+  }
+
+  private repoPath(): string {
+    const { accountId, namespace, repo } = this.config;
+    return `${this.baseUrl}/accounts/${accountId}/artifacts/namespaces/${namespace}/repos/${repo}`;
+  }
+
+  private async authHeaders(): Promise<HeadersInit> {
+    const token = await this.config.getAuthToken();
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  async listTree(): Promise<readonly ContentEntry[]> {
+    // /tree/:hash は :hash にブランチ名も受ける前提でブランチを渡す (beta・要確認)。
+    const url = `${this.repoPath()}/tree/${encodeURIComponent(this.branch)}`;
+    const response = await this.fetchFn(url, {
+      headers: await this.authHeaders(),
+    });
+    if (!response.ok) {
+      throw new ArtifactsRequestError(
+        response.status,
+        await safeText(response),
+      );
+    }
+    return parseTreeResponse(await response.json());
+  }
+
+  async readFile(path: string): Promise<Uint8Array | undefined> {
+    const url =
+      `${this.repoPath()}/file` +
+      `?ref=${encodeURIComponent(this.branch)}&path=${encodeURIComponent(path)}`;
+    const response = await this.fetchFn(url, {
+      headers: await this.authHeaders(),
+    });
+    if (response.status === HTTP_NOT_FOUND) return undefined;
+    if (!response.ok) {
+      throw new ArtifactsRequestError(
+        response.status,
+        await safeText(response),
+      );
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 200);
+  } catch {
+    return "<no body>";
+  }
+}
+
+/**
+ * tree エンドポイントのレスポンスを {@link ContentEntry}[] に変換する。
+ *
+ * 想定形状 (Cloudflare API の標準ラッパ + git tree 慣習):
+ *   { result: { tree: [ { path, type, oid|sha|hash }, ... ] }, success, ... }
+ * - type が "tree" (ディレクトリ) のエントリは除外し、blob (ファイル) のみ返す
+ * - ハッシュは oid / sha / hash のいずれかのフィールドから拾う
+ *
+ * ⚠️ 実際の beta レスポンス形状は要検証。差異があればこの関数だけを直す。
+ */
+export function parseTreeResponse(json: unknown): ContentEntry[] {
+  const tree = extractTreeArray(json);
+  const entries: ContentEntry[] = [];
+  for (const raw of tree) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const record = raw as Record<string, unknown>;
+    if (record.type === "tree") continue; // ディレクトリは除外
+    const path = record.path;
+    const hash = record.oid ?? record.sha ?? record.hash;
+    if (typeof path === "string" && typeof hash === "string") {
+      entries.push({ path, hash });
+    }
+  }
+  return entries;
+}
+
+function extractTreeArray(json: unknown): unknown[] {
+  if (typeof json !== "object" || json === null) return [];
+  const result = (json as { result?: unknown }).result;
+  const container = result ?? json;
+  if (Array.isArray(container)) return container;
+  if (typeof container === "object") {
+    const tree = (container as { tree?: unknown }).tree;
+    if (Array.isArray(tree)) return tree;
+  }
+  return [];
+}

--- a/app/backend/infra/artifacts/artifacts-content-store.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.ts
@@ -47,6 +47,8 @@ export class ArtifactsContentStore implements IContentStore {
   private readonly branch: string;
   private readonly baseUrl: string;
   private readonly fetchFn: typeof fetch;
+  /** トークンはストア (= 1 回の refresh) 内で使い回す。操作ごとの再発行を避ける。 */
+  private tokenPromise?: Promise<string>;
 
   constructor(private readonly config: ArtifactsContentStoreConfig) {
     this.branch = config.branch ?? "main";
@@ -60,7 +62,8 @@ export class ArtifactsContentStore implements IContentStore {
   }
 
   private async authHeaders(): Promise<HeadersInit> {
-    const token = await this.config.getAuthToken();
+    this.tokenPromise ??= this.config.getAuthToken();
+    const token = await this.tokenPromise;
     return { Authorization: `Bearer ${token}` };
   }
 
@@ -117,6 +120,18 @@ async function safeText(response: Response): Promise<string> {
  * ⚠️ 実際の beta レスポンス形状は要検証。差異があればこの関数だけを直す。
  */
 export function parseTreeResponse(json: unknown): ContentEntry[] {
+  // Cloudflare のエラーエンベロープ (HTTP 200 + success:false) は fail-loud で拒否する。
+  if (
+    typeof json === "object" &&
+    json !== null &&
+    (json as { success?: unknown }).success === false
+  ) {
+    throw new ArtifactsRequestError(
+      200,
+      "tree response reported success:false",
+    );
+  }
+
   const tree = extractTreeArray(json);
   const entries: ContentEntry[] = [];
   for (const raw of tree) {
@@ -132,14 +147,22 @@ export function parseTreeResponse(json: unknown): ContentEntry[] {
   return entries;
 }
 
+/**
+ * レスポンスからツリー配列を取り出す。空リポジトリ (認識できる形で tree が空) は [] を
+ * 返すが、**認識できない形は空にフォールバックせず throw する**。silent に [] を返すと
+ * refresh が「全ノート削除」と誤認してコンテンツを消しかねないため (fail-loud)。
+ */
 function extractTreeArray(json: unknown): unknown[] {
-  if (typeof json !== "object" || json === null) return [];
+  if (typeof json !== "object" || json === null) {
+    throw new ArtifactsRequestError(200, "unrecognized tree response");
+  }
   const result = (json as { result?: unknown }).result;
+  // json は非 null オブジェクトと確定済み。result が空なら json 自体を見る。
   const container = result ?? json;
   if (Array.isArray(container)) return container;
   if (typeof container === "object") {
     const tree = (container as { tree?: unknown }).tree;
     if (Array.isArray(tree)) return tree;
   }
-  return [];
+  throw new ArtifactsRequestError(200, "unrecognized tree response shape");
 }

--- a/app/backend/infra/d1/repositories/index.ts
+++ b/app/backend/infra/d1/repositories/index.ts
@@ -1,2 +1,4 @@
+export { D1NoteCommandRepository } from "./note.command-repository";
+export { D1NoteQueryRepository } from "./note.query-repository";
 export { D1UserCommandRepository } from "./user.command-repository";
 export { D1UserQueryRepository } from "./user.query-repository";

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -1,0 +1,23 @@
+import type { notes } from "~/backend/infra/d1/schema";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { entityId } from "~/backend/domain/shared";
+import { isoToPlainDate, unixToInstant } from "~/backend/infra/d1/temporal";
+
+/**
+ * D1 の行を Note エンティティに復元する。Command / Query リポジトリで共有する。
+ * slug / title / imageUrl は保存時に VO 経由で検証済みなので、ここでの再検証は
+ * 破損データの検知を兼ねる (不正なら VO factory が throw する)。
+ */
+export function rowToNote(row: typeof notes.$inferSelect): Note {
+  return Note.reconstruct({
+    id: entityId<"Note">(row.id),
+    slug: NoteSlug.create(row.slug),
+    title: NoteTitle.create(row.title),
+    summary: row.summary,
+    imageUrl: row.imageUrl === null ? undefined : ImageUrl.create(row.imageUrl),
+    publishedOn: isoToPlainDate(row.publishedOn),
+    lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
+    createdAt: unixToInstant(row.createdAt),
+    updatedAt: unixToInstant(row.updatedAt),
+  });
+}

--- a/app/backend/infra/d1/repositories/note.command-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.test.ts
@@ -1,0 +1,109 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function unpersistedNote(params: {
+  slug: string;
+  title: string;
+  summary?: string;
+  imageUrl?: string;
+  publishedOn?: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.title),
+    summary: params.summary ?? "summary",
+    imageUrl:
+      params.imageUrl === undefined
+        ? undefined
+        : ImageUrl.create(params.imageUrl),
+    publishedOn: Temporal.PlainDate.from(params.publishedOn ?? "2026-01-15"),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? "2026-01-20",
+    ),
+  });
+}
+
+describe("D1NoteCommandRepository", () => {
+  it("inserts a new note and returns it persisted", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+
+    const saved = await cmd.upsert(
+      unpersistedNote({
+        slug: "hello",
+        title: "Hello",
+        imageUrl: "/api/v1/notes/hello/assets/cover.png",
+      }),
+    );
+
+    expect(saved.id).toBeTruthy();
+    expect(saved.slug.toString()).toBe("hello");
+    expect(saved.title.toString()).toBe("Hello");
+    expect(saved.imageUrl?.toString()).toBe(
+      "/api/v1/notes/hello/assets/cover.png",
+    );
+    expect(saved.createdAt).toBeInstanceOf(Temporal.Instant);
+    expect(saved.updatedAt).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("stores a note without a cover image as undefined", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+    const saved = await cmd.upsert(unpersistedNote({ slug: "x", title: "X" }));
+    expect(saved.imageUrl).toBeUndefined();
+  });
+
+  it("updates in place on slug conflict, keeping the same id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const first = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Original" }),
+    );
+    const second = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Updated", summary: "new" }),
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.title.toString()).toBe("Updated");
+    expect(second.summary).toBe("new");
+    expect(second.createdAt.equals(first.createdAt)).toBe(true);
+
+    const { total } = await query.list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    expect(total).toBe(1);
+  });
+
+  it("deletes a note by slug", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    await cmd.upsert(unpersistedNote({ slug: "gone", title: "Gone" }));
+    await cmd.deleteBySlug(NoteSlug.create("gone"));
+
+    expect(await query.findBySlug(NoteSlug.create("gone"))).toBeUndefined();
+  });
+
+  it("deletes a note by id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const saved = await cmd.upsert(
+      unpersistedNote({ slug: "byid", title: "T" }),
+    );
+    await cmd.delete(saved.id);
+
+    expect(await query.findBySlug(NoteSlug.create("byid"))).toBeUndefined();
+  });
+});

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -1,0 +1,60 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteCommandRepository,
+  Note,
+  NoteId,
+  NoteSlug,
+} from "~/backend/domain/note";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { notes } from "~/backend/infra/d1/schema";
+import { instantToUnix, plainDateToIso } from "~/backend/infra/d1/temporal";
+
+export class D1NoteCommandRepository implements INoteCommandRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  /**
+   * slug をキーに upsert する。新規なら id と created_at を採番し、既存なら
+   * それらを保持したまま内容と updated_at を更新する。RETURNING で確定行を取り、
+   * 永続化済みエンティティを復元して返す。
+   */
+  async upsert(note: Note<IUnpersisted>): Promise<Note> {
+    const now = Temporal.Now.instant();
+    const nowUnix = instantToUnix(now);
+    const content = {
+      title: note.title.toString(),
+      summary: note.summary,
+      imageUrl: note.imageUrl?.toString() ?? null,
+      publishedOn: plainDateToIso(note.publishedOn),
+      lastModifiedOn: plainDateToIso(note.lastModifiedOn),
+      updatedAt: nowUnix,
+    };
+
+    const [row] = await this.db
+      .insert(notes)
+      .values({
+        id: crypto.randomUUID(),
+        slug: note.slug.toString(),
+        createdAt: nowUnix,
+        ...content,
+      })
+      .onConflictDoUpdate({ target: notes.slug, set: content })
+      .returning();
+
+    return rowToNote(row);
+  }
+
+  async deleteBySlug(slug: NoteSlug): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.slug, slug.toString()));
+  }
+
+  async delete(id: NoteId): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.id, id));
+  }
+}

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -1,0 +1,91 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function seed(params: {
+  slug: string;
+  publishedOn: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.slug),
+    summary: "s",
+    publishedOn: Temporal.PlainDate.from(params.publishedOn),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? params.publishedOn,
+    ),
+  });
+}
+
+async function seedNotes(cmd: D1NoteCommandRepository): Promise<void> {
+  await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-10" }));
+  await cmd.upsert(seed({ slug: "b", publishedOn: "2026-03-10" }));
+  await cmd.upsert(seed({ slug: "c", publishedOn: "2026-02-10" }));
+}
+
+describe("D1NoteQueryRepository", () => {
+  it("returns undefined for an unknown slug", async () => {
+    const query = new D1NoteQueryRepository(createTestD1());
+    expect(await query.findBySlug(NoteSlug.create("nope"))).toBeUndefined();
+  });
+
+  it("finds a note by slug after upsert", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      seed({ slug: "found", publishedOn: "2026-01-01" }),
+    );
+    const found = await new D1NoteQueryRepository(d1).findBySlug(
+      NoteSlug.create("found"),
+    );
+    expect(found?.slug.toString()).toBe("found");
+  });
+
+  it("orders by publishedOn descending by default sort field", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["b", "c", "a"]);
+  });
+
+  it("orders ascending when requested", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "asc",
+    });
+
+    expect(notes.map((n) => n.slug.toString())).toEqual(["a", "c", "b"]);
+  });
+
+  it("applies limit and offset for pagination while total stays the full count", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 1,
+      offset: 1,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
+});

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -88,4 +88,31 @@ describe("D1NoteQueryRepository", () => {
     expect(total).toBe(3);
     expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
   });
+
+  it("keeps a stable order across pages when dates tie (slug tiebreaker)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    // 全て同じ publishedOn。タイブレーカが無いと offset ページングで重複・欠落しうる。
+    await cmd.upsert(seed({ slug: "c", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "b", publishedOn: "2026-01-15" }));
+    const query = new D1NoteQueryRepository(d1);
+
+    const page1 = await query.list({
+      limit: 2,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    const page2 = await query.list({
+      limit: 2,
+      offset: 2,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    // slug 昇順で安定 → ページをまたいで a, b, c が重複なく並ぶ。
+    expect(page1.notes.map((n) => n.slug.toString())).toEqual(["a", "b"]);
+    expect(page2.notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -35,18 +35,21 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
 
   async list(query: NoteListQuery): Promise<NoteListResult> {
     const column = sortColumns[query.sortBy];
-    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+    const primary = query.direction === "asc" ? asc(column) : desc(column);
+    // 同じ日付のノート同士でも順序を安定させる決定的なタイブレーカ。slug は UNIQUE
+    // なので offset ページネーションで行の重複・欠落が起きない。
+    const tiebreaker = asc(notes.slug);
 
-    const rows = await this.db
-      .select()
-      .from(notes)
-      .orderBy(orderBy)
-      .limit(query.limit)
-      .offset(query.offset);
-
-    const [{ value: total }] = await this.db
-      .select({ value: count() })
-      .from(notes);
+    // 行取得と総件数取得は独立なので並行実行する (公開一覧のホットパスの往復を半減)。
+    const [rows, [{ value: total }]] = await Promise.all([
+      this.db
+        .select()
+        .from(notes)
+        .orderBy(primary, tiebreaker)
+        .limit(query.limit)
+        .offset(query.offset),
+      this.db.select({ value: count() }).from(notes),
+    ]);
 
     return { notes: rows.map((row) => rowToNote(row)), total };
   }

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -1,0 +1,53 @@
+import { asc, count, desc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteQueryRepository,
+  Note,
+  NoteListQuery,
+  NoteListResult,
+  NoteSlug,
+  NoteSortField,
+} from "~/backend/domain/note";
+import { notes } from "~/backend/infra/d1/schema";
+
+const sortColumns = {
+  publishedOn: notes.publishedOn,
+  lastModifiedOn: notes.lastModifiedOn,
+} as const satisfies Record<NoteSortField, unknown>;
+
+export class D1NoteQueryRepository implements INoteQueryRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  async findBySlug(slug: NoteSlug): Promise<Note | undefined> {
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .where(eq(notes.slug, slug.toString()))
+      .limit(1);
+    const row = rows.at(0);
+    return row === undefined ? undefined : rowToNote(row);
+  }
+
+  async list(query: NoteListQuery): Promise<NoteListResult> {
+    const column = sortColumns[query.sortBy];
+    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .orderBy(orderBy)
+      .limit(query.limit)
+      .offset(query.offset);
+
+    const [{ value: total }] = await this.db
+      .select({ value: count() })
+      .from(notes);
+
+    return { notes: rows.map((row) => rowToNote(row)), total };
+  }
+}

--- a/app/backend/infra/d1/schema/index.ts
+++ b/app/backend/infra/d1/schema/index.ts
@@ -1,1 +1,2 @@
+export { notes } from "./notes";
 export { users } from "./users";

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -1,0 +1,22 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * ノートのメタデータインデックス。コンテンツ正本は Cloudflare Artifacts、
+ * 本文 (MDAST) と画像は R2 にあり、この D1 テーブルは一覧・ルーティング用の
+ * メタデータだけを保持する (ADR 0005)。
+ *
+ * - published_on / last_modified_on: フロントマター由来の日付。ISO 日付文字列
+ *   ("YYYY-MM-DD") で保存し、辞書順ソート = 日付順ソートを利用する。
+ * - created_at / updated_at: D1 行の作成・更新時刻 (Unix 秒)。コンテンツ日付とは別。
+ */
+export const notes = sqliteTable("notes", {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull().unique(),
+  title: text("title").notNull(),
+  summary: text("summary").notNull(),
+  imageUrl: text("image_url"),
+  publishedOn: text("published_on").notNull(),
+  lastModifiedOn: text("last_modified_on").notNull(),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -13,3 +13,19 @@ export function instantToUnix(instant: Temporal.Instant): number {
 export function unixToInstant(unix: number): Temporal.Instant {
   return Temporal.Instant.fromEpochMilliseconds(unix * 1000);
 }
+
+/**
+ * Convert a Temporal.PlainDate to an ISO date string ("YYYY-MM-DD") for D1 text
+ * storage. ISO date strings sort lexicographically in the same order as the dates,
+ * so they can be ordered directly in SQL.
+ */
+export function plainDateToIso(date: Temporal.PlainDate): string {
+  return date.toString();
+}
+
+/**
+ * Convert an ISO date string ("YYYY-MM-DD") from D1 to a Temporal.PlainDate.
+ */
+export function isoToPlainDate(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -20,7 +20,10 @@ export function unixToInstant(unix: number): Temporal.Instant {
  * so they can be ordered directly in SQL.
  */
 export function plainDateToIso(date: Temporal.PlainDate): string {
-  return date.toString();
+  // calendarName: "never" で "[u-ca=...]" 注釈を落とし、常に "YYYY-MM-DD" にする。
+  // これを付けないと非 ISO カレンダーの PlainDate が注釈付き文字列になり、
+  // 往復とソートが壊れる。
+  return date.toString({ calendarName: "never" });
 }
 
 /**

--- a/docs/adr/0007-artifacts-read-via-binding-token-and-rest.md
+++ b/docs/adr/0007-artifacts-read-via-binding-token-and-rest.md
@@ -1,0 +1,62 @@
+# 0007. Artifacts のファイル読み取りは binding 発行トークン + REST API で行う
+
+- Status: Accepted
+- Date: 2026-07-05
+- Deciders: @yantene
+
+## Context / 背景
+
+[0005](0005-artifacts-as-content-source-of-truth.md) では、refresh 時に
+「Binding の `readTree` でツリーを取得し、変更ファイルだけ REST API で内容を取得する」
+と記した。しかし実装時点 (wrangler 4.107) の Artifacts Workers binding
+(`interface Artifacts`) が公開するのはリポジトリ管理系メソッド
+(`create` / `get` / `import` / `list` / `delete`) と、`ArtifactsRepo.createToken`
+によるアクセストークン発行のみで、**ファイル内容やツリーを binding から直接読む
+メソッド (`readTree` / `readBlob`) は存在しない**。
+
+したがって「binding でツリー・内容を読む」という 0005 の実装詳細はそのままでは成立せず、
+実際に使える API に合わせて読み取り経路を定め直す必要がある。
+
+## 検討した選択肢
+
+- **案 A: アカウント API トークンを secret に置き REST を叩く** — `CLOUDFLARE_API_TOKEN`
+  相当をワーカーの secret として持ち、Bearer で Artifacts REST API を呼ぶ。
+  - Pros: ドキュメントの REST 認証例と一致。実装が単純。
+  - Cons: アカウント全体を操作できる強い API トークンをワーカーに常駐させる。
+    secure by default に反する。
+- **案 B: binding で repo スコープの read トークンを発行し REST を叩く** — refresh 時に
+  `ARTIFACTS.get(repo).createToken("read")` で短命・読み取り専用・リポジトリ限定の
+  トークンを発行し、それを Bearer に載せて REST API でツリー・ファイルを読む。
+  - Pros: 権限最小化 (read only・repo 限定・短命)。binding を素直に活かす。
+  - Cons: リクエストごと (または一定間隔) にトークン発行の往復が要る。REST の
+    レスポンス形状が beta で不確定。
+
+## 決定
+
+案 B を採用する。0005 の「Artifacts を source of truth、D1/R2 をキャッシュ、blob
+ハッシュで変更検出」という骨子は維持したまま、**読み取り経路のみ**を次のように定める。
+
+- ドメインは技術非依存の `IContentStore` (`listTree()` / `readFile(path)`) を定義する。
+- infra の `ArtifactsContentStore` が実装し、Artifacts binding で発行した read トークンを
+  Bearer に載せて REST API を呼ぶ。
+  - ツリー: `GET /accounts/:acct/artifacts/namespaces/:ns/repos/:repo/tree/:ref`
+  - ファイル: `GET /accounts/:acct/artifacts/namespaces/:ns/repos/:repo/file?ref=&path=`
+- 変更検出は 0005 通り、ツリーが返す各ファイルのハッシュを D1 の保存済みと比較する。
+- accountId は secret (`ARTIFACTS_ACCOUNT_ID`)、namespace / repo / branch は wrangler の
+  vars で与える。未設定時は静かに劣化させず fail-loud で throw する。
+
+## 帰結 / Consequences
+
+- 良い面: 権限最小のトークンで読み取れる。ドメインは Artifacts を知らないまま
+  (`IContentStore`)、実装差し替えが効く。0005 の設計意図を壊さない。
+- 悪い面・トレードオフ: REST レスポンス (特に tree の JSON 形状) が beta のため未確定で、
+  実 API との突き合わせで解析の微修正が要る可能性がある。解析は
+  `parseTreeResponse` に隔離し、そこだけ直せば済むようにしてある。
+- 検証方法: `ArtifactsContentStore` を fetch モックでユニットテストする。実 Artifacts
+  リポジトリを用意でき次第、tree レスポンス形状を突き合わせて `parseTreeResponse` を確定する。
+
+## 参考 / More Information
+
+- [0005](0005-artifacts-as-content-source-of-truth.md)
+- [Cloudflare Artifacts REST API](https://developers.cloudflare.com/artifacts/api/rest-api/)
+- [Cloudflare Artifacts Workers binding](https://developers.cloudflare.com/artifacts/api/workers-binding/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,11 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                               | Status   |
-| ------------------------------------------------------ | ------------------------------------------------------ | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する           | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する          | Accepted |
+| #                                                      | タイトル                                                   | Status   |
+| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
 | [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,12 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                                   | Status   |
-| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
-| [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |
+| #                                                         | タイトル                                                              | Status   |
+| --------------------------------------------------------- | --------------------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)             | アーキテクチャ決定を ADR として記録する                               | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md)    | リポジトリ境界では Value Object / ブランド型で受け渡す                | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)               | Clean Architecture (DIP) と CQRS を採用する                           | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)                 | Inertia.js によるサーバー駆動 SPA を採用する                          | Accepted |
+| [0005](0005-artifacts-as-content-source-of-truth.md)      | Cloudflare Artifacts をコンテンツの source of truth にする            | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)                 | Markdown を HTML ではなく MDAST でフロントエンドに渡す                | Accepted |
+| [0007](0007-artifacts-read-via-binding-token-and-rest.md) | Artifacts のファイル読み取りは binding 発行トークン + REST API で行う | Accepted |

--- a/migrations/0001_create_notes_table.sql
+++ b/migrations/0001_create_notes_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `notes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`title` text NOT NULL,
+	`summary` text NOT NULL,
+	`image_url` text,
+	`published_on` text NOT NULL,
+	`last_modified_on` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `notes_slug_unique` ON `notes` (`slug`);

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,148 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "515262b0-5233-4003-a022-dfa0039ad1e7",
+  "prevId": "02defeaf-eeb8-4612-9ac8-b1965a1d4bea",
+  "tables": {
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780567722357,
       "tag": "0000_create_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1783215054973,
+      "tag": "0001_create_notes_table",
+      "breakpoints": true
     }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,11 @@
   },
   "vars": {
     "APP_ENV": "development",
+    // Artifacts (コンテンツ正本) の参照設定。REST 呼び出しに使う。
+    // ARTIFACTS_ACCOUNT_ID は secret として与える (`wrangler secret put`)。
+    "ARTIFACTS_NAMESPACE": "yantene",
+    "ARTIFACTS_REPO": "notes",
+    "ARTIFACTS_BRANCH": "main",
   },
   "d1_databases": [
     {
@@ -18,14 +23,22 @@
       "migrations_dir": "./migrations",
     },
   ],
-  // R2 bindings are available but currently unused.
-  // Uncomment when R2 storage is needed.
-  // "r2_buckets": [
-  // 	{
-  // 		"binding": "R2",
-  // 		"bucket_name": "yantene-development"
-  // 	}
-  // ],
+  // R2: パース済み MDAST と画像アセットのキャッシュ (ADR 0005)。
+  "r2_buckets": [
+    {
+      "binding": "R2",
+      "bucket_name": "yantene-development",
+    },
+  ],
+  // Artifacts: コンテンツ正本 (Markdown + 画像)。binding は repo 管理と read トークン
+  // 発行に使い、ファイル内容の読み取りは REST API で行う (ADR 0007)。
+  "artifacts": [
+    {
+      "binding": "ARTIFACTS",
+      "namespace": "yantene",
+      "remote": true,
+    },
+  ],
   "kv_namespaces": [
     {
       "binding": "KV",
@@ -45,6 +58,9 @@
       "workers_dev": true,
       "vars": {
         "APP_ENV": "staging",
+        "ARTIFACTS_NAMESPACE": "yantene",
+        "ARTIFACTS_REPO": "notes",
+        "ARTIFACTS_BRANCH": "main",
       },
       "d1_databases": [
         {
@@ -53,12 +69,19 @@
           "migrations_dir": "./migrations",
         },
       ],
-      // "r2_buckets": [
-      // 	{
-      // 		"binding": "R2",
-      // 		"bucket_name": "yantene-staging"
-      // 	}
-      // ],
+      "r2_buckets": [
+        {
+          "binding": "R2",
+          "bucket_name": "yantene-staging",
+        },
+      ],
+      "artifacts": [
+        {
+          "binding": "ARTIFACTS",
+          "namespace": "yantene",
+          "remote": true,
+        },
+      ],
       "kv_namespaces": [
         {
           "binding": "KV",
@@ -73,6 +96,9 @@
     "production": {
       "vars": {
         "APP_ENV": "production",
+        "ARTIFACTS_NAMESPACE": "yantene",
+        "ARTIFACTS_REPO": "notes",
+        "ARTIFACTS_BRANCH": "main",
       },
       "d1_databases": [
         {
@@ -81,12 +107,19 @@
           "migrations_dir": "./migrations",
         },
       ],
-      // "r2_buckets": [
-      // 	{
-      // 		"binding": "R2",
-      // 		"bucket_name": "yantene-production"
-      // 	}
-      // ],
+      "r2_buckets": [
+        {
+          "binding": "R2",
+          "bucket_name": "yantene-production",
+        },
+      ],
+      "artifacts": [
+        {
+          "binding": "ARTIFACTS",
+          "namespace": "yantene",
+          "remote": true,
+        },
+      ],
       "kv_namespaces": [
         {
           "binding": "KV",


### PR DESCRIPTION
## 概要

Closes #6 / depends on #4 #5 (stacked on PR #14)

コンテンツ正本 (Cloudflare Artifacts) を読むための接続基盤と R2 キャッシュ用バインディング。

> ℹ️ #14 → #13 にスタック。親 PR マージ後に差分は本 PR 分になります。

## やったこと

- **ドメイン** — 技術非依存の `IContentStore` (`listTree()` / `readFile(path)`) と `ContentEntry`
- **infra** — `ArtifactsContentStore`。**Artifacts binding は `readTree` を持たない**ため、binding で発行した repo スコープ read トークンを Bearer に載せ REST API でツリー/ファイルを読む。tree レスポンス解析は `parseTreeResponse` に隔離
- **Composition Root** — `resolveContentStore` (accountId は secret、未設定は fail-loud)
- **wrangler.jsonc** — R2 バケット + Artifacts バインディング + `ARTIFACTS_*` vars を全環境に追加
- **ADR 0007** — 0005 の「binding の readTree」前提を実 API に合わせて是正
- fetch モックによるユニットテスト

## ⚠️ 要確認事項 (beta)

- Artifacts REST の **tree レスポンス JSON 形状**は beta で未確定。`parseTreeResponse` に想定形状 (`{ result: { tree: [{ path, type, oid }] } }`) を隔離してあり、実 API と差異があればそこだけ直せば済みます。
- wrangler.jsonc の `namespace: "yantene"` / `ARTIFACTS_REPO: "notes"` は仮の値です。**実際の Artifacts namespace / repo 名に合わせてください。** また `ARTIFACTS_ACCOUNT_ID` を secret として設定する必要があります。
- deploy には R2 バケット (`yantene-*`) と Artifacts リポジトリの実プロビジョニングが必要です。

## CI について

⚠️ `deploy-preview` は Cloudflare Secrets/リソース都合で失敗します。`wrangler-config` (dry-run) は R2/Artifacts バインディング込みで pass します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S