### PR TITLE
feat(services): NotesRefreshService を実装する

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -1,7 +1,7 @@
 # 環境構成
 
-| 環境        | トリガー          | DB                                         |
-| ----------- | ----------------- | ------------------------------------------ |
+| 環境        | トリガー          | DB                          |
+| ----------- | ----------------- | --------------------------- |
 | development | ローカル          | yantene-development (local) |
 | staging     | PR / push to main | yantene-staging             |
 | production  | GitHub Release    | yantene-production          |

--- a/.claude/rules/product.md
+++ b/.claude/rules/product.md
@@ -51,7 +51,7 @@ NoteTitle / ImageUrl 等の VO に変換する。
 ```yaml
 ---
 title: 記事タイトル
-imageUrl: ./cover.png       # 相対パス → アセット API URL に解決される
+imageUrl: ./cover.png # 相対パス → アセット API URL に解決される
 publishedOn: 2026-01-15
 lastModifiedOn: 2026-01-20
 ---

--- a/app/backend/domain/content/content-store.interface.ts
+++ b/app/backend/domain/content/content-store.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * コンテンツ正本 (Markdown 本文・画像アセット) の読み取り口。
+ * ドメインはストレージ技術 (Cloudflare Artifacts 等) を知らない。infra が実装する。
+ *
+ * 変更検出はコンテンツハッシュで行う: refresh 時にツリーを取得し、各ファイルの
+ * ハッシュを D1 の保存済みと比較して、変わったファイルだけ読み直す (ADR 0005)。
+ */
+
+/** ツリー内の 1 ファイル。hash はそのファイル内容のリビジョン識別子。 */
+export interface ContentEntry {
+  /** 正本内のパス (例: "notes/my-note.md", "notes/my-note/cover.png")。 */
+  readonly path: string;
+  /** ファイル内容のハッシュ (変更検出用)。 */
+  readonly hash: string;
+}
+
+export interface IContentStore {
+  /** 全ファイルのパスとハッシュを列挙する (変更検出のためのスナップショット)。 */
+  listTree(): Promise<readonly ContentEntry[]>;
+
+  /**
+   * パス指定でファイルの生バイト列を読む。存在しなければ undefined を返す。
+   */
+  readFile(path: string): Promise<Uint8Array | undefined>;
+}

--- a/app/backend/domain/content/index.ts
+++ b/app/backend/domain/content/index.ts
@@ -1,0 +1,1 @@
+export type { ContentEntry, IContentStore } from "./content-store.interface";

--- a/app/backend/domain/note/errors.ts
+++ b/app/backend/domain/note/errors.ts
@@ -1,0 +1,6 @@
+export class NoteNotFoundError extends Error {
+  readonly name = "NoteNotFoundError";
+  constructor(slug: string) {
+    super(`Note not found: ${slug}`);
+  }
+}

--- a/app/backend/domain/note/image-url.vo.test.ts
+++ b/app/backend/domain/note/image-url.vo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+
+describe("ImageUrl", () => {
+  it("accepts a root-relative asset API path", () => {
+    const url = "/api/v1/notes/my-note/assets/cover.png";
+    expect(ImageUrl.create(url).toString()).toBe(url);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(ImageUrl.create("  /a/b.png  ").toString()).toBe("/a/b.png");
+  });
+
+  it("rejects unresolved relative paths", () => {
+    expect(() => ImageUrl.create("./cover.png")).toThrow(InvalidImageUrlError);
+    expect(() => ImageUrl.create("cover.png")).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects absolute URLs, including raw Artifacts URLs", () => {
+    // 絶対 URL は Artifacts の直接 URL 露出につながり、CSP (img-src 'self') でも
+    // 表示できないため弾く。
+    expect(() => ImageUrl.create("https://example.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() =>
+      ImageUrl.create("https://artifacts.example/raw/notes/x/cover.png"),
+    ).toThrow(InvalidImageUrlError);
+  });
+
+  it("rejects protocol-relative and non-http schemes", () => {
+    expect(() => ImageUrl.create("//evil.com/a.png")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("javascript:alert(1)")).toThrow(
+      InvalidImageUrlError,
+    );
+    expect(() => ImageUrl.create("data:image/png;base64,AAAA")).toThrow(
+      InvalidImageUrlError,
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => ImageUrl.create(" ".repeat(3))).toThrow(InvalidImageUrlError);
+  });
+
+  it("compares by value with equals", () => {
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/a.png"))).toBe(
+      true,
+    );
+    expect(ImageUrl.create("/a.png").equals(ImageUrl.create("/b.png"))).toBe(
+      false,
+    );
+  });
+});

--- a/app/backend/domain/note/image-url.vo.ts
+++ b/app/backend/domain/note/image-url.vo.ts
@@ -1,0 +1,48 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// ノートのカバー画像 URL。フロントマターの相対パス (`./cover.png`) は
+// アセット API URL (ルート相対 `/api/v1/notes/<slug>/assets/...`) に解決してから
+// VO 化する前提で、ここでは解決済みの「ルート相対パス」だけを受け入れる。
+//
+// 絶対 URL は弾く。これは 2 つの規約を同時に満たすため:
+//   - Artifacts の直接 URL を露出させない (product 規約)。絶対 URL を許すと
+//     未解決の生 Artifacts URL がそのまま通り得る。
+//   - 画像はアセット API (self) 経由で配信する。CSP の img-src は 'self' data:
+//     のみで外部ホストの画像は表示できないため、絶対 URL を持たせても無意味。
+const MAX_LENGTH = 2048;
+
+export class InvalidImageUrlError extends Error {
+  readonly name = "InvalidImageUrlError";
+}
+
+export class ImageUrl implements IValueObject<ImageUrl> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): ImageUrl {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidImageUrlError(
+        `Image URL must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    // ルート相対パスのみ。"//" 始まり (プロトコル相対 = 絶対 URL 相当) は弾く。
+    if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+      throw new InvalidImageUrlError(
+        "Image URL must be a root-relative asset path (e.g. /api/v1/notes/<slug>/assets/<file>)",
+      );
+    }
+    return new ImageUrl(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: ImageUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -1,0 +1,14 @@
+export { NoteNotFoundError } from "./errors";
+export { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
+export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+export { Note } from "./note.entity";
+export type { NoteId } from "./note.entity";
+export type { INoteCommandRepository } from "./note.command-repository.interface";
+export type {
+  INoteQueryRepository,
+  NoteListQuery,
+  NoteListResult,
+  NoteSortField,
+  SortDirection,
+} from "./note.query-repository.interface";

--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -4,6 +4,10 @@ export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
 export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
 export { Note } from "./note.entity";
 export type { NoteId } from "./note.entity";
+export type {
+  CachedAsset,
+  INoteContentCache,
+} from "./note-content-cache.interface";
 export type { INoteCommandRepository } from "./note.command-repository.interface";
 export type {
   INoteQueryRepository,

--- a/app/backend/domain/note/note-content-cache.interface.ts
+++ b/app/backend/domain/note/note-content-cache.interface.ts
@@ -1,0 +1,27 @@
+import type { NoteSlug } from "./note-slug.vo";
+
+/** キャッシュされた画像アセット。 */
+export interface CachedAsset {
+  readonly bytes: Uint8Array;
+  readonly contentType: string;
+}
+
+/**
+ * ノート本文 (パース済み MDAST) と画像アセットのキャッシュ。
+ * 通常リクエストはこのキャッシュから配信し、Artifacts には触らない (ADR 0005)。
+ * ドメインはストレージ技術 (R2) を知らない。infra が実装する。
+ */
+export interface INoteContentCache {
+  /** パース済み MDAST (JSON 化可能なオブジェクト) を保存する。 */
+  putMdast(slug: NoteSlug, mdast: unknown): Promise<void>;
+  /** パース済み MDAST を取得する。無ければ undefined (unknown に含まれる)。 */
+  getMdast(slug: NoteSlug): Promise<unknown>;
+
+  /** 画像アセットを保存する (path はノート内の相対パス)。 */
+  putAsset(slug: NoteSlug, path: string, asset: CachedAsset): Promise<void>;
+  /** 画像アセットを取得する。無ければ undefined。 */
+  getAsset(slug: NoteSlug, path: string): Promise<CachedAsset | undefined>;
+
+  /** ノートのキャッシュ (MDAST + 全アセット) を削除する。 */
+  deleteNote(slug: NoteSlug): Promise<void>;
+}

--- a/app/backend/domain/note/note-slug.vo.test.ts
+++ b/app/backend/domain/note/note-slug.vo.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+
+describe("NoteSlug", () => {
+  it("accepts lowercase alphanumerics with single hyphens", () => {
+    expect(NoteSlug.create("hello-world-2026").toString()).toBe(
+      "hello-world-2026",
+    );
+  });
+
+  it("trims and lowercases input", () => {
+    expect(NoteSlug.create("  Hello-World  ").toString()).toBe("hello-world");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => NoteSlug.create(" ".repeat(3))).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects leading, trailing, and doubled hyphens", () => {
+    expect(() => NoteSlug.create("-hello")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello-")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello--world")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects characters outside [a-z0-9-]", () => {
+    expect(() => NoteSlug.create("hello_world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("hello world")).toThrow(InvalidNoteSlugError);
+    expect(() => NoteSlug.create("こんにちは")).toThrow(InvalidNoteSlugError);
+  });
+
+  it("rejects slugs longer than 200 characters", () => {
+    expect(() => NoteSlug.create("a".repeat(201))).toThrow(
+      InvalidNoteSlugError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("foo"))).toBe(true);
+    expect(NoteSlug.create("foo").equals(NoteSlug.create("bar"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteSlug.create("foo-bar").toJSON()).toBe("foo-bar");
+  });
+});

--- a/app/backend/domain/note/note-slug.vo.ts
+++ b/app/backend/domain/note/note-slug.vo.ts
@@ -1,0 +1,47 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// スラグは URL パスセグメントに乗る識別子。小文字英数字とハイフンのみ許可する。
+// ハイフンの位置制約 (先頭・末尾・連続の禁止) はネストした量指定子の正規表現で
+// まとめて表現すると ReDoS 検知に触れるため、単純な文字クラス検査 + 個別チェックに分ける。
+const slugCharsPattern = /^[a-z0-9-]+$/;
+const MAX_LENGTH = 200;
+
+export class InvalidNoteSlugError extends Error {
+  readonly name = "InvalidNoteSlugError";
+}
+
+export class NoteSlug implements IValueObject<NoteSlug> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteSlug {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteSlugError(
+        `Note slug must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    if (
+      !slugCharsPattern.test(trimmed) ||
+      trimmed.startsWith("-") ||
+      trimmed.endsWith("-") ||
+      trimmed.includes("--")
+    ) {
+      throw new InvalidNoteSlugError(
+        "Note slug must be lowercase alphanumerics separated by single hyphens",
+      );
+    }
+    return new NoteSlug(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteSlug): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note-title.vo.test.ts
+++ b/app/backend/domain/note/note-title.vo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
+
+describe("NoteTitle", () => {
+  it("keeps the original casing and symbols", () => {
+    expect(NoteTitle.create("Hello, World! 記事").toString()).toBe(
+      "Hello, World! 記事",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(NoteTitle.create("  Title  ").toString()).toBe("Title");
+  });
+
+  it("rejects empty or whitespace-only input", () => {
+    expect(() => NoteTitle.create("")).toThrow(InvalidNoteTitleError);
+    expect(() => NoteTitle.create(" ".repeat(3))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("rejects titles longer than 200 characters", () => {
+    expect(() => NoteTitle.create("あ".repeat(201))).toThrow(
+      InvalidNoteTitleError,
+    );
+  });
+
+  it("compares by value with equals", () => {
+    expect(NoteTitle.create("A").equals(NoteTitle.create("A"))).toBe(true);
+    expect(NoteTitle.create("A").equals(NoteTitle.create("B"))).toBe(false);
+  });
+
+  it("serializes to a plain string via toJSON", () => {
+    expect(NoteTitle.create("Title").toJSON()).toBe("Title");
+  });
+});

--- a/app/backend/domain/note/note-title.vo.ts
+++ b/app/backend/domain/note/note-title.vo.ts
@@ -1,0 +1,35 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// タイトルはフロントマター由来の表示文字列。大文字小文字・記号はそのまま保つが、
+// 前後の空白は正規化し、空文字と過長を弾く。
+const MAX_LENGTH = 200;
+
+export class InvalidNoteTitleError extends Error {
+  readonly name = "InvalidNoteTitleError";
+}
+
+export class NoteTitle implements IValueObject<NoteTitle> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteTitle {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteTitleError(
+        `Note title must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    return new NoteTitle(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteTitle): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note.command-repository.interface.ts
+++ b/app/backend/domain/note/note.command-repository.interface.ts
@@ -1,0 +1,18 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note, NoteId } from "./note.entity";
+import type { IUnpersisted } from "~/backend/domain/shared";
+
+export interface INoteCommandRepository {
+  /**
+   * ノートのメタデータを slug をキーに upsert する。
+   * refresh 時に Artifacts の内容で D1 を同期するための操作。
+   * 既存 slug があれば更新、無ければ新規作成し、永続化済みエンティティを返す。
+   */
+  upsert(note: Note<IUnpersisted>): Promise<Note>;
+
+  /** slug のノートを削除する (Artifacts から消えたノートの掃除に使う)。 */
+  deleteBySlug(slug: NoteSlug): Promise<void>;
+
+  /** id のノートを削除する。 */
+  delete(id: NoteId): Promise<void>;
+}

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -19,9 +19,11 @@ describe("Note.create", () => {
       summary: "A short summary.",
       publishedOn,
       lastModifiedOn,
+      sourceHash: "abc123",
     });
 
     expect(note.id).toBeUndefined();
+    expect(note.sourceHash).toBe("abc123");
     expect(note.createdAt).toBeUndefined();
     expect(note.updatedAt).toBeUndefined();
     expect(note.slug.toString()).toBe("my-note");
@@ -40,6 +42,7 @@ describe("Note.create", () => {
       imageUrl: ImageUrl.create("/api/v1/notes/my-note/assets/cover.png"),
       publishedOn,
       lastModifiedOn,
+      sourceHash: "h",
     });
 
     expect(note.imageUrl?.toString()).toBe(
@@ -60,6 +63,7 @@ describe("Note.reconstruct", () => {
       imageUrl: undefined,
       publishedOn,
       lastModifiedOn,
+      sourceHash: "h",
       createdAt,
       updatedAt,
     });

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -1,0 +1,71 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { ImageUrl } from "./image-url.vo";
+import { NoteSlug } from "./note-slug.vo";
+import { NoteTitle } from "./note-title.vo";
+import { Note } from "./note.entity";
+import { entityId } from "~/backend/domain/shared";
+
+const slug = NoteSlug.create("my-note");
+const title = NoteTitle.create("My Note");
+const publishedOn = Temporal.PlainDate.from("2026-01-15");
+const lastModifiedOn = Temporal.PlainDate.from("2026-01-20");
+
+describe("Note.create", () => {
+  it("builds an unpersisted note with undefined id and timestamps", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "A short summary.",
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.id).toBeUndefined();
+    expect(note.createdAt).toBeUndefined();
+    expect(note.updatedAt).toBeUndefined();
+    expect(note.slug.toString()).toBe("my-note");
+    expect(note.title.toString()).toBe("My Note");
+    expect(note.summary).toBe("A short summary.");
+    expect(note.imageUrl).toBeUndefined();
+    expect(note.publishedOn.toString()).toBe("2026-01-15");
+    expect(note.lastModifiedOn.toString()).toBe("2026-01-20");
+  });
+
+  it("retains an optional cover image", () => {
+    const note = Note.create({
+      slug,
+      title,
+      summary: "s",
+      imageUrl: ImageUrl.create("/api/v1/notes/my-note/assets/cover.png"),
+      publishedOn,
+      lastModifiedOn,
+    });
+
+    expect(note.imageUrl?.toString()).toBe(
+      "/api/v1/notes/my-note/assets/cover.png",
+    );
+  });
+});
+
+describe("Note.reconstruct", () => {
+  it("restores a persisted note with id and timestamps", () => {
+    const createdAt = Temporal.Instant.from("2026-01-15T00:00:00Z");
+    const updatedAt = Temporal.Instant.from("2026-01-20T00:00:00Z");
+    const note = Note.reconstruct({
+      id: entityId<"Note">("note-1"),
+      slug,
+      title,
+      summary: "s",
+      imageUrl: undefined,
+      publishedOn,
+      lastModifiedOn,
+      createdAt,
+      updatedAt,
+    });
+
+    expect(note.id).toBe("note-1");
+    expect(note.createdAt.equals(createdAt)).toBe(true);
+    expect(note.updatedAt.equals(updatedAt)).toBe(true);
+  });
+});

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -22,6 +22,11 @@ interface NoteFields<T extends IPersisted | IUnpersisted> {
   readonly publishedOn: Temporal.PlainDate;
   /** フロントマター由来の最終更新日 (日付のみ)。 */
   readonly lastModifiedOn: Temporal.PlainDate;
+  /**
+   * コンテンツ正本 (Markdown) のリビジョン識別子。refresh 時の変更検出に使う
+   * (Artifacts のツリーが返すファイルハッシュ)。
+   */
+  readonly sourceHash: string;
   /** D1 行の作成・更新時刻 (永続化メタデータ。コンテンツ日付とは別)。 */
   readonly createdAt: T["createdAt"];
   readonly updatedAt: T["updatedAt"];
@@ -42,6 +47,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     imageUrl?: ImageUrl;
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
+    sourceHash: string;
   }): Note<IUnpersisted> {
     return new Note({
       id: undefined,
@@ -51,6 +57,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
       imageUrl: params.imageUrl,
       publishedOn: params.publishedOn,
       lastModifiedOn: params.lastModifiedOn,
+      sourceHash: params.sourceHash,
       createdAt: undefined,
       updatedAt: undefined,
     });
@@ -64,6 +71,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     imageUrl: ImageUrl | undefined;
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
+    sourceHash: string;
     createdAt: Temporal.Instant;
     updatedAt: Temporal.Instant;
   }): Note {
@@ -96,6 +104,10 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
 
   get lastModifiedOn(): Temporal.PlainDate {
     return this.fields.lastModifiedOn;
+  }
+
+  get sourceHash(): string {
+    return this.fields.sourceHash;
   }
 
   get createdAt(): NoteFields<T>["createdAt"] {

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -1,0 +1,108 @@
+import type { ImageUrl } from "./image-url.vo";
+import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTitle } from "./note-title.vo";
+import type { Temporal } from "@js-temporal/polyfill";
+import type {
+  EntityId,
+  IPersisted,
+  IUnpersisted,
+} from "~/backend/domain/shared";
+
+export type NoteId = EntityId<"Note">;
+
+interface NoteFields<T extends IPersisted | IUnpersisted> {
+  readonly id: T["id"] extends string ? NoteId : undefined;
+  readonly slug: NoteSlug;
+  readonly title: NoteTitle;
+  /** MDAST から自動抽出した一覧用の要約 (先頭 160 文字)。手書きしない。 */
+  readonly summary: string;
+  /** カバー画像 URL。フロントマターに imageUrl が無ければ undefined。 */
+  readonly imageUrl: ImageUrl | undefined;
+  /** フロントマター由来の公開日 (日付のみ)。 */
+  readonly publishedOn: Temporal.PlainDate;
+  /** フロントマター由来の最終更新日 (日付のみ)。 */
+  readonly lastModifiedOn: Temporal.PlainDate;
+  /** D1 行の作成・更新時刻 (永続化メタデータ。コンテンツ日付とは別)。 */
+  readonly createdAt: T["createdAt"];
+  readonly updatedAt: T["updatedAt"];
+}
+
+/**
+ * ノート集約。Markdown 記事のメタデータを表す。
+ * 本文 (MDAST) と画像アセットは別ストレージ (R2) にあり、本エンティティは
+ * D1 のメタデータインデックスに対応する。
+ */
+export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
+  private constructor(private readonly fields: NoteFields<T>) {}
+
+  static create(params: {
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl?: ImageUrl;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+  }): Note<IUnpersisted> {
+    return new Note({
+      id: undefined,
+      slug: params.slug,
+      title: params.title,
+      summary: params.summary,
+      imageUrl: params.imageUrl,
+      publishedOn: params.publishedOn,
+      lastModifiedOn: params.lastModifiedOn,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  }
+
+  static reconstruct(params: {
+    id: NoteId;
+    slug: NoteSlug;
+    title: NoteTitle;
+    summary: string;
+    imageUrl: ImageUrl | undefined;
+    publishedOn: Temporal.PlainDate;
+    lastModifiedOn: Temporal.PlainDate;
+    createdAt: Temporal.Instant;
+    updatedAt: Temporal.Instant;
+  }): Note {
+    return new Note(params);
+  }
+
+  get id(): NoteFields<T>["id"] {
+    return this.fields.id;
+  }
+
+  get slug(): NoteSlug {
+    return this.fields.slug;
+  }
+
+  get title(): NoteTitle {
+    return this.fields.title;
+  }
+
+  get summary(): string {
+    return this.fields.summary;
+  }
+
+  get imageUrl(): ImageUrl | undefined {
+    return this.fields.imageUrl;
+  }
+
+  get publishedOn(): Temporal.PlainDate {
+    return this.fields.publishedOn;
+  }
+
+  get lastModifiedOn(): Temporal.PlainDate {
+    return this.fields.lastModifiedOn;
+  }
+
+  get createdAt(): NoteFields<T>["createdAt"] {
+    return this.fields.createdAt;
+  }
+
+  get updatedAt(): NoteFields<T>["updatedAt"] {
+    return this.fields.updatedAt;
+  }
+}

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -1,0 +1,29 @@
+import type { NoteSlug } from "./note-slug.vo";
+import type { Note } from "./note.entity";
+
+/** 一覧の並び替え基準。 */
+export type NoteSortField = "publishedOn" | "lastModifiedOn";
+
+/** 並び順。 */
+export type SortDirection = "asc" | "desc";
+
+/** ページネーション + ソートのクエリ条件。 */
+export interface NoteListQuery {
+  /** 取得件数の上限 (1 以上)。 */
+  readonly limit: number;
+  /** スキップ件数 (0 以上)。 */
+  readonly offset: number;
+  readonly sortBy: NoteSortField;
+  readonly direction: SortDirection;
+}
+
+/** 一覧の取得結果。total は絞り込み前の全件数 (ページネーション用)。 */
+export interface NoteListResult {
+  readonly notes: readonly Note[];
+  readonly total: number;
+}
+
+export interface INoteQueryRepository {
+  findBySlug(slug: NoteSlug): Promise<Note | undefined>;
+  list(query: NoteListQuery): Promise<NoteListResult>;
+}

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -26,4 +26,9 @@ export interface NoteListResult {
 export interface INoteQueryRepository {
   findBySlug(slug: NoteSlug): Promise<Note | undefined>;
   list(query: NoteListQuery): Promise<NoteListResult>;
+  /**
+   * 全ノートの slug → sourceHash の対応を返す。refresh の変更検出に使う
+   * (Artifacts のツリーが返すハッシュと突き合わせる)。
+   */
+  listSourceHashes(): Promise<ReadonlyMap<string, string>>;
 }

--- a/app/backend/handlers/notes/refresh.handler.ts
+++ b/app/backend/handlers/notes/refresh.handler.ts
@@ -1,0 +1,31 @@
+import { Hono } from "hono";
+import { resolveContentStore } from "./resolve-content-store";
+import {
+  D1NoteCommandRepository,
+  D1NoteQueryRepository,
+} from "~/backend/infra/d1/repositories";
+import { R2NoteContentCache } from "~/backend/infra/r2/r2-note-content-cache";
+import { NotesRefreshService } from "~/backend/services/notes-refresh.service";
+
+/**
+ * ノート同期 (refresh) の JSON API ルータ。認証必須 (index.ts で requireSession 配下に
+ * マウントする)。Composition Root として具象を生成し NotesRefreshService に注入する。
+ *
+ * POST /refresh → Artifacts を D1 + R2 に同期し、処理結果サマリを返す。
+ */
+export function createRefreshRouter(): Hono<{ Bindings: Env }> {
+  const router = new Hono<{ Bindings: Env }>();
+
+  router.post("/refresh", async (c) => {
+    const service = new NotesRefreshService(
+      resolveContentStore(c.env),
+      new D1NoteCommandRepository(c.env.D1),
+      new D1NoteQueryRepository(c.env.D1),
+      new R2NoteContentCache(c.env.R2),
+    );
+    const result = await service.refresh();
+    return c.json(result);
+  });
+
+  return router;
+}

--- a/app/backend/handlers/notes/resolve-content-store.ts
+++ b/app/backend/handlers/notes/resolve-content-store.ts
@@ -1,0 +1,34 @@
+import type { IContentStore } from "~/backend/domain/content";
+import { ArtifactsContentStore } from "~/backend/infra/artifacts/artifacts-content-store";
+
+/**
+ * Composition Root: env から Artifacts の設定を解決して {@link IContentStore} を生成する。
+ *
+ * - namespace / repo / branch は wrangler.jsonc の vars。
+ * - accountId は secret (`wrangler secret put ARTIFACTS_ACCOUNT_ID`)。未設定なら
+ *   静かにフォールバックせず fail-loud で throw する (secure by default)。
+ * - read トークンは Artifacts binding でリポジトリスコープに発行し、Bearer に載せる。
+ */
+export function resolveContentStore(env: Env): IContentStore {
+  const accountId = (env as unknown as { ARTIFACTS_ACCOUNT_ID?: unknown })
+    .ARTIFACTS_ACCOUNT_ID;
+  if (typeof accountId !== "string" || accountId.length === 0) {
+    throw new Error(
+      "ARTIFACTS_ACCOUNT_ID is required to read content from Artifacts.",
+    );
+  }
+
+  const repo = env.ARTIFACTS_REPO;
+
+  return new ArtifactsContentStore({
+    accountId,
+    namespace: env.ARTIFACTS_NAMESPACE,
+    repo,
+    branch: env.ARTIFACTS_BRANCH,
+    getAuthToken: async () => {
+      const handle = await env.ARTIFACTS.get(repo);
+      const token = await handle.createToken("read");
+      return token.plaintext;
+    },
+  });
+}

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -6,6 +6,7 @@ import {
   type SecureHeadersVariables,
 } from "hono/secure-headers";
 import { createApiRouter } from "./handlers/api";
+import { createRefreshRouter } from "./handlers/notes/refresh.handler";
 import { createPagesRouter } from "./handlers/pages";
 import { UserNotFoundError } from "~/backend/domain/user";
 import { requireSession } from "~/backend/middleware/auth";
@@ -50,6 +51,8 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 // 認証必須 JSON API
 app.use("/api/*", requireSession);
 app.route("/api", createApiRouter());
+// ノート同期 (Artifacts → D1 + R2)。認証必須。
+app.route("/api", createRefreshRouter());
 
 // Inertia.js ページルート (locale + inertia ミドルウェアは router 内で適用)
 app.route("/", createPagesRouter());

--- a/app/backend/infra/artifacts/artifacts-content-store.test.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ArtifactsContentStore,
+  ArtifactsRequestError,
+  parseTreeResponse,
+} from "./artifacts-content-store";
+
+function store(fetchFn: typeof fetch): ArtifactsContentStore {
+  return new ArtifactsContentStore({
+    accountId: "acct-1",
+    namespace: "yantene",
+    repo: "notes",
+    branch: "main",
+    baseUrl: "https://api.test/client/v4",
+    getAuthToken: () => Promise.resolve("tok-123"),
+    fetchFn,
+  });
+}
+
+describe("parseTreeResponse", () => {
+  it("keeps blob entries and drops directories", () => {
+    const json = {
+      result: {
+        tree: [
+          { path: "notes/a.md", type: "blob", oid: "h1" },
+          { path: "notes", type: "tree", oid: "h2" },
+          { path: "notes/a/cover.png", type: "blob", oid: "h3" },
+        ],
+      },
+    };
+    expect(parseTreeResponse(json)).toEqual([
+      { path: "notes/a.md", hash: "h1" },
+      { path: "notes/a/cover.png", hash: "h3" },
+    ]);
+  });
+
+  it("accepts sha or hash as the hash field and a bare array", () => {
+    expect(
+      parseTreeResponse([
+        { path: "x.md", sha: "s1" },
+        { path: "y.md", hash: "s2" },
+      ]),
+    ).toEqual([
+      { path: "x.md", hash: "s1" },
+      { path: "y.md", hash: "s2" },
+    ]);
+  });
+
+  it("ignores malformed entries and non-objects", () => {
+    // null / 数値 / hash 欠落エントリはすべて落ちる。
+    expect(
+      parseTreeResponse({ result: { tree: [null, 1, { path: "z" }] } }),
+    ).toEqual([]);
+    expect(parseTreeResponse("nope")).toEqual([]);
+  });
+});
+
+describe("ArtifactsContentStore", () => {
+  it("lists the tree with a Bearer token from getAuthToken", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(
+        Response.json({ result: { tree: [{ path: "a.md", oid: "h1" }] } }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const entries = await store(fetchFn).listTree();
+    expect(entries).toEqual([{ path: "a.md", hash: "h1" }]);
+
+    const [url, init] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://api.test/client/v4/accounts/acct-1/artifacts/namespaces/yantene/repos/notes/tree/main",
+    );
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer tok-123",
+    });
+  });
+
+  it("reads a file's bytes by path", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response(bytes)),
+    ) as unknown as typeof fetch;
+
+    const result = await store(fetchFn).readFile("notes/a.md");
+    expect(result).toEqual(bytes);
+
+    const [url] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://api.test/client/v4/accounts/acct-1/artifacts/namespaces/yantene/repos/notes/file?ref=main&path=notes%2Fa.md",
+    );
+  });
+
+  it("returns undefined when a file is missing (404)", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response("not found", { status: 404 })),
+    ) as unknown as typeof fetch;
+    expect(await store(fetchFn).readFile("missing.md")).toBeUndefined();
+  });
+
+  it("throws ArtifactsRequestError on other non-ok responses", async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve(new Response("boom", { status: 500 })),
+    ) as unknown as typeof fetch;
+    await expect(store(fetchFn).listTree()).rejects.toBeInstanceOf(
+      ArtifactsRequestError,
+    );
+  });
+});

--- a/app/backend/infra/artifacts/artifacts-content-store.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.ts
@@ -1,0 +1,145 @@
+import type { ContentEntry, IContentStore } from "~/backend/domain/content";
+
+const DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4";
+const HTTP_NOT_FOUND = 404;
+
+export interface ArtifactsContentStoreConfig {
+  /** Cloudflare アカウント ID。 */
+  readonly accountId: string;
+  /** Artifacts の namespace。 */
+  readonly namespace: string;
+  /** リポジトリ名。 */
+  readonly repo: string;
+  /** 読み取り対象のブランチ (既定 "main")。 */
+  readonly branch?: string;
+  /** REST API のベース URL (テスト差し替え用)。 */
+  readonly baseUrl?: string;
+  /**
+   * Bearer 認証トークンを取得する。Composition Root では Artifacts binding で
+   * リポジトリスコープの read トークンを発行して渡す想定。
+   */
+  readonly getAuthToken: () => Promise<string>;
+  /** fetch 実装 (テスト差し替え用)。 */
+  readonly fetchFn?: typeof fetch;
+}
+
+export class ArtifactsRequestError extends Error {
+  readonly name = "ArtifactsRequestError";
+  constructor(
+    readonly status: number,
+    detail: string,
+  ) {
+    super(`Artifacts request failed (${String(status)}): ${detail}`);
+  }
+}
+
+/**
+ * Cloudflare Artifacts の REST API を用いた {@link IContentStore} 実装。
+ *
+ * Artifacts の Workers binding はファイル読み取りを提供しない (repo 管理 + トークン
+ * 発行のみ) ため、binding で発行した read トークンを Bearer に載せて REST API を叩く
+ * (ADR 0005 / 0007)。
+ *
+ * ⚠️ tree エンドポイントのレスポンス JSON 形状は beta のため実 API で要確認。
+ * 解析は {@link parseTreeResponse} に隔離してあり、形状が違えばそこだけ直せばよい。
+ */
+export class ArtifactsContentStore implements IContentStore {
+  private readonly branch: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(private readonly config: ArtifactsContentStoreConfig) {
+    this.branch = config.branch ?? "main";
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.fetchFn = config.fetchFn ?? fetch;
+  }
+
+  private repoPath(): string {
+    const { accountId, namespace, repo } = this.config;
+    return `${this.baseUrl}/accounts/${accountId}/artifacts/namespaces/${namespace}/repos/${repo}`;
+  }
+
+  private async authHeaders(): Promise<HeadersInit> {
+    const token = await this.config.getAuthToken();
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  async listTree(): Promise<readonly ContentEntry[]> {
+    // /tree/:hash は :hash にブランチ名も受ける前提でブランチを渡す (beta・要確認)。
+    const url = `${this.repoPath()}/tree/${encodeURIComponent(this.branch)}`;
+    const response = await this.fetchFn(url, {
+      headers: await this.authHeaders(),
+    });
+    if (!response.ok) {
+      throw new ArtifactsRequestError(
+        response.status,
+        await safeText(response),
+      );
+    }
+    return parseTreeResponse(await response.json());
+  }
+
+  async readFile(path: string): Promise<Uint8Array | undefined> {
+    const url =
+      `${this.repoPath()}/file` +
+      `?ref=${encodeURIComponent(this.branch)}&path=${encodeURIComponent(path)}`;
+    const response = await this.fetchFn(url, {
+      headers: await this.authHeaders(),
+    });
+    if (response.status === HTTP_NOT_FOUND) return undefined;
+    if (!response.ok) {
+      throw new ArtifactsRequestError(
+        response.status,
+        await safeText(response),
+      );
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 200);
+  } catch {
+    return "<no body>";
+  }
+}
+
+/**
+ * tree エンドポイントのレスポンスを {@link ContentEntry}[] に変換する。
+ *
+ * 想定形状 (Cloudflare API の標準ラッパ + git tree 慣習):
+ *   { result: { tree: [ { path, type, oid|sha|hash }, ... ] }, success, ... }
+ * - type が "tree" (ディレクトリ) のエントリは除外し、blob (ファイル) のみ返す
+ * - ハッシュは oid / sha / hash のいずれかのフィールドから拾う
+ *
+ * ⚠️ 実際の beta レスポンス形状は要検証。差異があればこの関数だけを直す。
+ */
+export function parseTreeResponse(json: unknown): ContentEntry[] {
+  const tree = extractTreeArray(json);
+  const entries: ContentEntry[] = [];
+  for (const raw of tree) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const record = raw as Record<string, unknown>;
+    if (record.type === "tree") continue; // ディレクトリは除外
+    const path = record.path;
+    const hash = record.oid ?? record.sha ?? record.hash;
+    if (typeof path === "string" && typeof hash === "string") {
+      entries.push({ path, hash });
+    }
+  }
+  return entries;
+}
+
+function extractTreeArray(json: unknown): unknown[] {
+  if (typeof json !== "object" || json === null) return [];
+  const result = (json as { result?: unknown }).result;
+  const container = result ?? json;
+  if (Array.isArray(container)) return container;
+  if (typeof container === "object") {
+    const tree = (container as { tree?: unknown }).tree;
+    if (Array.isArray(tree)) return tree;
+  }
+  return [];
+}

--- a/app/backend/infra/d1/repositories/index.ts
+++ b/app/backend/infra/d1/repositories/index.ts
@@ -1,2 +1,4 @@
+export { D1NoteCommandRepository } from "./note.command-repository";
+export { D1NoteQueryRepository } from "./note.query-repository";
 export { D1UserCommandRepository } from "./user.command-repository";
 export { D1UserQueryRepository } from "./user.query-repository";

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -17,6 +17,7 @@ export function rowToNote(row: typeof notes.$inferSelect): Note {
     imageUrl: row.imageUrl === null ? undefined : ImageUrl.create(row.imageUrl),
     publishedOn: isoToPlainDate(row.publishedOn),
     lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
+    sourceHash: row.sourceHash,
     createdAt: unixToInstant(row.createdAt),
     updatedAt: unixToInstant(row.updatedAt),
   });

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -1,0 +1,23 @@
+import type { notes } from "~/backend/infra/d1/schema";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { entityId } from "~/backend/domain/shared";
+import { isoToPlainDate, unixToInstant } from "~/backend/infra/d1/temporal";
+
+/**
+ * D1 の行を Note エンティティに復元する。Command / Query リポジトリで共有する。
+ * slug / title / imageUrl は保存時に VO 経由で検証済みなので、ここでの再検証は
+ * 破損データの検知を兼ねる (不正なら VO factory が throw する)。
+ */
+export function rowToNote(row: typeof notes.$inferSelect): Note {
+  return Note.reconstruct({
+    id: entityId<"Note">(row.id),
+    slug: NoteSlug.create(row.slug),
+    title: NoteTitle.create(row.title),
+    summary: row.summary,
+    imageUrl: row.imageUrl === null ? undefined : ImageUrl.create(row.imageUrl),
+    publishedOn: isoToPlainDate(row.publishedOn),
+    lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
+    createdAt: unixToInstant(row.createdAt),
+    updatedAt: unixToInstant(row.updatedAt),
+  });
+}

--- a/app/backend/infra/d1/repositories/note.command-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.test.ts
@@ -1,0 +1,109 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function unpersistedNote(params: {
+  slug: string;
+  title: string;
+  summary?: string;
+  imageUrl?: string;
+  publishedOn?: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.title),
+    summary: params.summary ?? "summary",
+    imageUrl:
+      params.imageUrl === undefined
+        ? undefined
+        : ImageUrl.create(params.imageUrl),
+    publishedOn: Temporal.PlainDate.from(params.publishedOn ?? "2026-01-15"),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? "2026-01-20",
+    ),
+  });
+}
+
+describe("D1NoteCommandRepository", () => {
+  it("inserts a new note and returns it persisted", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+
+    const saved = await cmd.upsert(
+      unpersistedNote({
+        slug: "hello",
+        title: "Hello",
+        imageUrl: "/api/v1/notes/hello/assets/cover.png",
+      }),
+    );
+
+    expect(saved.id).toBeTruthy();
+    expect(saved.slug.toString()).toBe("hello");
+    expect(saved.title.toString()).toBe("Hello");
+    expect(saved.imageUrl?.toString()).toBe(
+      "/api/v1/notes/hello/assets/cover.png",
+    );
+    expect(saved.createdAt).toBeInstanceOf(Temporal.Instant);
+    expect(saved.updatedAt).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("stores a note without a cover image as undefined", async () => {
+    const cmd = new D1NoteCommandRepository(createTestD1());
+    const saved = await cmd.upsert(unpersistedNote({ slug: "x", title: "X" }));
+    expect(saved.imageUrl).toBeUndefined();
+  });
+
+  it("updates in place on slug conflict, keeping the same id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const first = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Original" }),
+    );
+    const second = await cmd.upsert(
+      unpersistedNote({ slug: "post", title: "Updated", summary: "new" }),
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.title.toString()).toBe("Updated");
+    expect(second.summary).toBe("new");
+    expect(second.createdAt.equals(first.createdAt)).toBe(true);
+
+    const { total } = await query.list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    expect(total).toBe(1);
+  });
+
+  it("deletes a note by slug", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    await cmd.upsert(unpersistedNote({ slug: "gone", title: "Gone" }));
+    await cmd.deleteBySlug(NoteSlug.create("gone"));
+
+    expect(await query.findBySlug(NoteSlug.create("gone"))).toBeUndefined();
+  });
+
+  it("deletes a note by id", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const query = new D1NoteQueryRepository(d1);
+
+    const saved = await cmd.upsert(
+      unpersistedNote({ slug: "byid", title: "T" }),
+    );
+    await cmd.delete(saved.id);
+
+    expect(await query.findBySlug(NoteSlug.create("byid"))).toBeUndefined();
+  });
+});

--- a/app/backend/infra/d1/repositories/note.command-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.test.ts
@@ -13,6 +13,7 @@ function unpersistedNote(params: {
   imageUrl?: string;
   publishedOn?: string;
   lastModifiedOn?: string;
+  sourceHash?: string;
 }): Note<IUnpersisted> {
   return Note.create({
     slug: NoteSlug.create(params.slug),
@@ -26,6 +27,7 @@ function unpersistedNote(params: {
     lastModifiedOn: Temporal.PlainDate.from(
       params.lastModifiedOn ?? "2026-01-20",
     ),
+    sourceHash: params.sourceHash ?? "hash-0",
   });
 }
 

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -1,0 +1,60 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteCommandRepository,
+  Note,
+  NoteId,
+  NoteSlug,
+} from "~/backend/domain/note";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { notes } from "~/backend/infra/d1/schema";
+import { instantToUnix, plainDateToIso } from "~/backend/infra/d1/temporal";
+
+export class D1NoteCommandRepository implements INoteCommandRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  /**
+   * slug をキーに upsert する。新規なら id と created_at を採番し、既存なら
+   * それらを保持したまま内容と updated_at を更新する。RETURNING で確定行を取り、
+   * 永続化済みエンティティを復元して返す。
+   */
+  async upsert(note: Note<IUnpersisted>): Promise<Note> {
+    const now = Temporal.Now.instant();
+    const nowUnix = instantToUnix(now);
+    const content = {
+      title: note.title.toString(),
+      summary: note.summary,
+      imageUrl: note.imageUrl?.toString() ?? null,
+      publishedOn: plainDateToIso(note.publishedOn),
+      lastModifiedOn: plainDateToIso(note.lastModifiedOn),
+      updatedAt: nowUnix,
+    };
+
+    const [row] = await this.db
+      .insert(notes)
+      .values({
+        id: crypto.randomUUID(),
+        slug: note.slug.toString(),
+        createdAt: nowUnix,
+        ...content,
+      })
+      .onConflictDoUpdate({ target: notes.slug, set: content })
+      .returning();
+
+    return rowToNote(row);
+  }
+
+  async deleteBySlug(slug: NoteSlug): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.slug, slug.toString()));
+  }
+
+  async delete(id: NoteId): Promise<void> {
+    await this.db.delete(notes).where(eq(notes.id, id));
+  }
+}

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -33,6 +33,7 @@ export class D1NoteCommandRepository implements INoteCommandRepository {
       imageUrl: note.imageUrl?.toString() ?? null,
       publishedOn: plainDateToIso(note.publishedOn),
       lastModifiedOn: plainDateToIso(note.lastModifiedOn),
+      sourceHash: note.sourceHash,
       updatedAt: nowUnix,
     };
 

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -1,0 +1,91 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { D1NoteCommandRepository } from "./note.command-repository";
+import { D1NoteQueryRepository } from "./note.query-repository";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function seed(params: {
+  slug: string;
+  publishedOn: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.slug),
+    summary: "s",
+    publishedOn: Temporal.PlainDate.from(params.publishedOn),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? params.publishedOn,
+    ),
+  });
+}
+
+async function seedNotes(cmd: D1NoteCommandRepository): Promise<void> {
+  await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-10" }));
+  await cmd.upsert(seed({ slug: "b", publishedOn: "2026-03-10" }));
+  await cmd.upsert(seed({ slug: "c", publishedOn: "2026-02-10" }));
+}
+
+describe("D1NoteQueryRepository", () => {
+  it("returns undefined for an unknown slug", async () => {
+    const query = new D1NoteQueryRepository(createTestD1());
+    expect(await query.findBySlug(NoteSlug.create("nope"))).toBeUndefined();
+  });
+
+  it("finds a note by slug after upsert", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      seed({ slug: "found", publishedOn: "2026-01-01" }),
+    );
+    const found = await new D1NoteQueryRepository(d1).findBySlug(
+      NoteSlug.create("found"),
+    );
+    expect(found?.slug.toString()).toBe("found");
+  });
+
+  it("orders by publishedOn descending by default sort field", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["b", "c", "a"]);
+  });
+
+  it("orders ascending when requested", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "asc",
+    });
+
+    expect(notes.map((n) => n.slug.toString())).toEqual(["a", "c", "b"]);
+  });
+
+  it("applies limit and offset for pagination while total stays the full count", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 1,
+      offset: 1,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    expect(total).toBe(3);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
+});

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -88,4 +88,31 @@ describe("D1NoteQueryRepository", () => {
     expect(total).toBe(3);
     expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
   });
+
+  it("keeps a stable order across pages when dates tie (slug tiebreaker)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    // 全て同じ publishedOn。タイブレーカが無いと offset ページングで重複・欠落しうる。
+    await cmd.upsert(seed({ slug: "c", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "a", publishedOn: "2026-01-15" }));
+    await cmd.upsert(seed({ slug: "b", publishedOn: "2026-01-15" }));
+    const query = new D1NoteQueryRepository(d1);
+
+    const page1 = await query.list({
+      limit: 2,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    const page2 = await query.list({
+      limit: 2,
+      offset: 2,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+
+    // slug 昇順で安定 → ページをまたいで a, b, c が重複なく並ぶ。
+    expect(page1.notes.map((n) => n.slug.toString())).toEqual(["a", "b"]);
+    expect(page2.notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -19,6 +19,7 @@ function seed(params: {
     lastModifiedOn: Temporal.PlainDate.from(
       params.lastModifiedOn ?? params.publishedOn,
     ),
+    sourceHash: `hash-${params.slug}`,
   });
 }
 
@@ -87,6 +88,16 @@ describe("D1NoteQueryRepository", () => {
 
     expect(total).toBe(3);
     expect(notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
+
+  it("returns slug -> sourceHash map for change detection", async () => {
+    const d1 = createTestD1();
+    await seedNotes(new D1NoteCommandRepository(d1));
+
+    const hashes = await new D1NoteQueryRepository(d1).listSourceHashes();
+    expect(hashes.get("a")).toBe("hash-a");
+    expect(hashes.get("b")).toBe("hash-b");
+    expect(hashes.size).toBe(3);
   });
 
   it("keeps a stable order across pages when dates tie (slug tiebreaker)", async () => {

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -35,18 +35,21 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
 
   async list(query: NoteListQuery): Promise<NoteListResult> {
     const column = sortColumns[query.sortBy];
-    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+    const primary = query.direction === "asc" ? asc(column) : desc(column);
+    // 同じ日付のノート同士でも順序を安定させる決定的なタイブレーカ。slug は UNIQUE
+    // なので offset ページネーションで行の重複・欠落が起きない。
+    const tiebreaker = asc(notes.slug);
 
-    const rows = await this.db
-      .select()
-      .from(notes)
-      .orderBy(orderBy)
-      .limit(query.limit)
-      .offset(query.offset);
-
-    const [{ value: total }] = await this.db
-      .select({ value: count() })
-      .from(notes);
+    // 行取得と総件数取得は独立なので並行実行する (公開一覧のホットパスの往復を半減)。
+    const [rows, [{ value: total }]] = await Promise.all([
+      this.db
+        .select()
+        .from(notes)
+        .orderBy(primary, tiebreaker)
+        .limit(query.limit)
+        .offset(query.offset),
+      this.db.select({ value: count() }).from(notes),
+    ]);
 
     return { notes: rows.map((row) => rowToNote(row)), total };
   }

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -53,4 +53,11 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
 
     return { notes: rows.map((row) => rowToNote(row)), total };
   }
+
+  async listSourceHashes(): Promise<ReadonlyMap<string, string>> {
+    const rows = await this.db
+      .select({ slug: notes.slug, sourceHash: notes.sourceHash })
+      .from(notes);
+    return new Map(rows.map((row) => [row.slug, row.sourceHash]));
+  }
 }

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -1,0 +1,53 @@
+import { asc, count, desc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { rowToNote } from "./note-row";
+import type {
+  INoteQueryRepository,
+  Note,
+  NoteListQuery,
+  NoteListResult,
+  NoteSlug,
+  NoteSortField,
+} from "~/backend/domain/note";
+import { notes } from "~/backend/infra/d1/schema";
+
+const sortColumns = {
+  publishedOn: notes.publishedOn,
+  lastModifiedOn: notes.lastModifiedOn,
+} as const satisfies Record<NoteSortField, unknown>;
+
+export class D1NoteQueryRepository implements INoteQueryRepository {
+  private readonly db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  async findBySlug(slug: NoteSlug): Promise<Note | undefined> {
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .where(eq(notes.slug, slug.toString()))
+      .limit(1);
+    const row = rows.at(0);
+    return row === undefined ? undefined : rowToNote(row);
+  }
+
+  async list(query: NoteListQuery): Promise<NoteListResult> {
+    const column = sortColumns[query.sortBy];
+    const orderBy = query.direction === "asc" ? asc(column) : desc(column);
+
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .orderBy(orderBy)
+      .limit(query.limit)
+      .offset(query.offset);
+
+    const [{ value: total }] = await this.db
+      .select({ value: count() })
+      .from(notes);
+
+    return { notes: rows.map((row) => rowToNote(row)), total };
+  }
+}

--- a/app/backend/infra/d1/schema/index.ts
+++ b/app/backend/infra/d1/schema/index.ts
@@ -1,1 +1,2 @@
+export { notes } from "./notes";
 export { users } from "./users";

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -1,0 +1,22 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * ノートのメタデータインデックス。コンテンツ正本は Cloudflare Artifacts、
+ * 本文 (MDAST) と画像は R2 にあり、この D1 テーブルは一覧・ルーティング用の
+ * メタデータだけを保持する (ADR 0005)。
+ *
+ * - published_on / last_modified_on: フロントマター由来の日付。ISO 日付文字列
+ *   ("YYYY-MM-DD") で保存し、辞書順ソート = 日付順ソートを利用する。
+ * - created_at / updated_at: D1 行の作成・更新時刻 (Unix 秒)。コンテンツ日付とは別。
+ */
+export const notes = sqliteTable("notes", {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull().unique(),
+  title: text("title").notNull(),
+  summary: text("summary").notNull(),
+  imageUrl: text("image_url"),
+  publishedOn: text("published_on").notNull(),
+  lastModifiedOn: text("last_modified_on").notNull(),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -17,6 +17,8 @@ export const notes = sqliteTable("notes", {
   imageUrl: text("image_url"),
   publishedOn: text("published_on").notNull(),
   lastModifiedOn: text("last_modified_on").notNull(),
+  // コンテンツ正本 (Markdown) のリビジョン識別子。refresh の変更検出に使う。
+  sourceHash: text("source_hash").notNull(),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -17,8 +17,10 @@ export const notes = sqliteTable("notes", {
   imageUrl: text("image_url"),
   publishedOn: text("published_on").notNull(),
   lastModifiedOn: text("last_modified_on").notNull(),
-  // コンテンツ正本 (Markdown) のリビジョン識別子。refresh の変更検出に使う。
-  sourceHash: text("source_hash").notNull(),
+  // コンテンツ正本のリビジョン識別子 (Markdown + アセットの合成ハッシュ)。
+  // refresh の変更検出に使う。既存行への ADD COLUMN を安全にするため DEFAULT '' を持つ
+  // (空ハッシュは次回 refresh で必ず不一致になり再処理される)。
+  sourceHash: text("source_hash").notNull().default(""),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -13,3 +13,19 @@ export function instantToUnix(instant: Temporal.Instant): number {
 export function unixToInstant(unix: number): Temporal.Instant {
   return Temporal.Instant.fromEpochMilliseconds(unix * 1000);
 }
+
+/**
+ * Convert a Temporal.PlainDate to an ISO date string ("YYYY-MM-DD") for D1 text
+ * storage. ISO date strings sort lexicographically in the same order as the dates,
+ * so they can be ordered directly in SQL.
+ */
+export function plainDateToIso(date: Temporal.PlainDate): string {
+  return date.toString();
+}
+
+/**
+ * Convert an ISO date string ("YYYY-MM-DD") from D1 to a Temporal.PlainDate.
+ */
+export function isoToPlainDate(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}

--- a/app/backend/infra/d1/temporal.ts
+++ b/app/backend/infra/d1/temporal.ts
@@ -20,7 +20,10 @@ export function unixToInstant(unix: number): Temporal.Instant {
  * so they can be ordered directly in SQL.
  */
 export function plainDateToIso(date: Temporal.PlainDate): string {
-  return date.toString();
+  // calendarName: "never" で "[u-ca=...]" 注釈を落とし、常に "YYYY-MM-DD" にする。
+  // これを付けないと非 ISO カレンダーの PlainDate が注釈付き文字列になり、
+  // 往復とソートが壊れる。
+  return date.toString({ calendarName: "never" });
 }
 
 /**

--- a/app/backend/infra/r2/r2-note-content-cache.test.ts
+++ b/app/backend/infra/r2/r2-note-content-cache.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { R2NoteContentCache } from "./r2-note-content-cache";
+import { NoteSlug } from "~/backend/domain/note";
+
+interface StoredObject {
+  bytes: Uint8Array;
+  contentType: string | undefined;
+}
+
+/** テスト用の最小 in-memory R2Bucket。get / put / list / delete のみ実装する。 */
+function createTestR2(): {
+  bucket: R2Bucket;
+  store: Map<string, StoredObject>;
+} {
+  const store = new Map<string, StoredObject>();
+
+  const bucket = {
+    put: (
+      key: string,
+      value: string | ArrayBuffer | ArrayBufferView,
+      options?: { httpMetadata?: { contentType?: string } },
+    ) => {
+      const bytes = toBytes(value);
+      store.set(key, {
+        bytes,
+        contentType: options?.httpMetadata?.contentType,
+      });
+      return Promise.resolve();
+    },
+    get: (key: string) => {
+      const found = store.get(key);
+      if (found === undefined) return Promise.resolve(null);
+      return Promise.resolve({
+        text: () => Promise.resolve(new TextDecoder().decode(found.bytes)),
+        arrayBuffer: () =>
+          Promise.resolve(
+            found.bytes.buffer.slice(
+              found.bytes.byteOffset,
+              found.bytes.byteOffset + found.bytes.byteLength,
+            ),
+          ),
+        httpMetadata: { contentType: found.contentType },
+      });
+    },
+    list: (options?: { prefix?: string }) => {
+      const prefix = options?.prefix ?? "";
+      const objects: { key: string }[] = [];
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) objects.push({ key });
+      }
+      return Promise.resolve({ objects, truncated: false });
+    },
+    delete: (keys: string | string[]) => {
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      for (const key of keyList) store.delete(key);
+      return Promise.resolve();
+    },
+  } as unknown as R2Bucket;
+
+  return { bucket, store };
+}
+
+function toBytes(value: string | ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (typeof value === "string") return new TextEncoder().encode(value);
+  return new Uint8Array(value instanceof ArrayBuffer ? value : value.buffer);
+}
+
+const slug = NoteSlug.create("my-note");
+
+describe("R2NoteContentCache", () => {
+  it("round-trips MDAST as JSON", async () => {
+    const { bucket } = createTestR2();
+    const cache = new R2NoteContentCache(bucket);
+
+    await cache.putMdast(slug, { type: "root", children: [] });
+    expect(await cache.getMdast(slug)).toEqual({ type: "root", children: [] });
+  });
+
+  it("returns undefined for a missing MDAST", async () => {
+    const cache = new R2NoteContentCache(createTestR2().bucket);
+    expect(await cache.getMdast(slug)).toBeUndefined();
+  });
+
+  it("round-trips an asset with its content type", async () => {
+    const cache = new R2NoteContentCache(createTestR2().bucket);
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    await cache.putAsset(slug, "cover.png", {
+      bytes,
+      contentType: "image/png",
+    });
+    const asset = await cache.getAsset(slug, "cover.png");
+
+    expect(asset?.bytes).toEqual(bytes);
+    expect(asset?.contentType).toBe("image/png");
+  });
+
+  it("deletes all cached objects for a note", async () => {
+    const { bucket, store } = createTestR2();
+    const cache = new R2NoteContentCache(bucket);
+
+    await cache.putMdast(slug, { type: "root" });
+    await cache.putAsset(slug, "cover.png", {
+      bytes: new Uint8Array([1]),
+      contentType: "image/png",
+    });
+    expect(store.size).toBe(2);
+
+    await cache.deleteNote(slug);
+    expect(store.size).toBe(0);
+  });
+});

--- a/app/backend/infra/r2/r2-note-content-cache.ts
+++ b/app/backend/infra/r2/r2-note-content-cache.ts
@@ -1,0 +1,75 @@
+import type {
+  CachedAsset,
+  INoteContentCache,
+  NoteSlug,
+} from "~/backend/domain/note";
+
+const JSON_CONTENT_TYPE = "application/json";
+const DEFAULT_ASSET_CONTENT_TYPE = "application/octet-stream";
+
+/**
+ * R2 をバックエンドにした {@link INoteContentCache} 実装。
+ * キーはノート単位のプレフィックス `notes/<slug>/` 配下にまとめ、削除時は
+ * プレフィックス列挙で一括削除できるようにする。
+ */
+export class R2NoteContentCache implements INoteContentCache {
+  constructor(private readonly bucket: R2Bucket) {}
+
+  private prefix(slug: NoteSlug): string {
+    return `notes/${slug.toString()}/`;
+  }
+
+  private mdastKey(slug: NoteSlug): string {
+    return `${this.prefix(slug)}mdast.json`;
+  }
+
+  private assetKey(slug: NoteSlug, path: string): string {
+    return `${this.prefix(slug)}assets/${path}`;
+  }
+
+  async putMdast(slug: NoteSlug, mdast: unknown): Promise<void> {
+    await this.bucket.put(this.mdastKey(slug), JSON.stringify(mdast), {
+      httpMetadata: { contentType: JSON_CONTENT_TYPE },
+    });
+  }
+
+  async getMdast(slug: NoteSlug): Promise<unknown> {
+    const object = await this.bucket.get(this.mdastKey(slug));
+    if (object === null) return undefined;
+    return JSON.parse(await object.text());
+  }
+
+  async putAsset(
+    slug: NoteSlug,
+    path: string,
+    asset: CachedAsset,
+  ): Promise<void> {
+    await this.bucket.put(this.assetKey(slug, path), asset.bytes, {
+      httpMetadata: { contentType: asset.contentType },
+    });
+  }
+
+  async getAsset(
+    slug: NoteSlug,
+    path: string,
+  ): Promise<CachedAsset | undefined> {
+    const object = await this.bucket.get(this.assetKey(slug, path));
+    if (object === null) return undefined;
+    return {
+      bytes: new Uint8Array(await object.arrayBuffer()),
+      contentType:
+        object.httpMetadata?.contentType ?? DEFAULT_ASSET_CONTENT_TYPE,
+    };
+  }
+
+  async deleteNote(slug: NoteSlug): Promise<void> {
+    const prefix = this.prefix(slug);
+    let cursor: string | undefined;
+    do {
+      const listing = await this.bucket.list({ prefix, cursor });
+      const keys = listing.objects.map((object) => object.key);
+      if (keys.length > 0) await this.bucket.delete(keys);
+      cursor = listing.truncated ? listing.cursor : undefined;
+    } while (cursor !== undefined);
+  }
+}

--- a/app/backend/services/asset-content-type.test.ts
+++ b/app/backend/services/asset-content-type.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { contentTypeForPath } from "./asset-content-type";
+
+describe("contentTypeForPath", () => {
+  it("maps known image extensions (case-insensitively)", () => {
+    expect(contentTypeForPath("cover.png")).toBe("image/png");
+    expect(contentTypeForPath("a/b.JPG")).toBe("image/jpeg");
+    expect(contentTypeForPath("icon.svg")).toBe("image/svg+xml");
+    expect(contentTypeForPath("photo.webp")).toBe("image/webp");
+  });
+
+  it("falls back to octet-stream for unknown or missing extensions", () => {
+    expect(contentTypeForPath("file.bin")).toBe("application/octet-stream");
+    expect(contentTypeForPath("noext")).toBe("application/octet-stream");
+  });
+});

--- a/app/backend/services/asset-content-type.ts
+++ b/app/backend/services/asset-content-type.ts
@@ -1,0 +1,19 @@
+const contentTypes = new Map<string, string>([
+  ["png", "image/png"],
+  ["jpg", "image/jpeg"],
+  ["jpeg", "image/jpeg"],
+  ["gif", "image/gif"],
+  ["webp", "image/webp"],
+  ["avif", "image/avif"],
+  ["svg", "image/svg+xml"],
+]);
+
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+/** ファイルパスの拡張子から Content-Type を推定する (画像アセット向け)。 */
+export function contentTypeForPath(path: string): string {
+  const dot = path.lastIndexOf(".");
+  if (dot === -1) return DEFAULT_CONTENT_TYPE;
+  const ext = path.slice(dot + 1).toLowerCase();
+  return contentTypes.get(ext) ?? DEFAULT_CONTENT_TYPE;
+}

--- a/app/backend/services/note-asset-url.test.ts
+++ b/app/backend/services/note-asset-url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveAssetUrl } from "./note-asset-url";
+
+describe("resolveAssetUrl", () => {
+  it("resolves ./relative paths to the asset API URL", () => {
+    expect(resolveAssetUrl("my-note", "./cover.png")).toBe(
+      "/api/v1/notes/my-note/assets/cover.png",
+    );
+  });
+
+  it("resolves bare relative paths", () => {
+    expect(resolveAssetUrl("my-note", "img/a.png")).toBe(
+      "/api/v1/notes/my-note/assets/img/a.png",
+    );
+  });
+
+  it("leaves absolute URLs and root-relative paths untouched", () => {
+    expect(resolveAssetUrl("n", "https://example.com/a.png")).toBe(
+      "https://example.com/a.png",
+    );
+    expect(resolveAssetUrl("n", "/already/resolved.png")).toBe(
+      "/already/resolved.png",
+    );
+  });
+});

--- a/app/backend/services/note-asset-url.test.ts
+++ b/app/backend/services/note-asset-url.test.ts
@@ -14,6 +14,16 @@ describe("resolveAssetUrl", () => {
     );
   });
 
+  it("collapses ./ and ../ segments instead of producing a malformed URL", () => {
+    expect(resolveAssetUrl("my-note", "./img/./a.png")).toBe(
+      "/api/v1/notes/my-note/assets/img/a.png",
+    );
+    // ../ は畳まれる (assets/../ のような壊れたパスにはならない)。
+    expect(resolveAssetUrl("my-note", "../x.png")).toBe(
+      "/api/v1/notes/my-note/x.png",
+    );
+  });
+
   it("leaves absolute URLs and root-relative paths untouched", () => {
     expect(resolveAssetUrl("n", "https://example.com/a.png")).toBe(
       "https://example.com/a.png",

--- a/app/backend/services/note-asset-url.ts
+++ b/app/backend/services/note-asset-url.ts
@@ -1,11 +1,15 @@
 /**
  * ノート内の相対的な画像 URL をアセット API URL (ルート相対) に解決する。
- * 絶対 URL (http/https) やルート相対 (`/...`) は解決済みとみなしそのまま返す。
- * 相対パス (`./cover.png` / `cover.png`) を `/api/v1/notes/<slug>/assets/<path>` にする。
+ * 絶対 URL (http/https 等スキーム付き) やルート相対 (`/...`) は解決済みとみなしそのまま返す。
+ * 相対パス (`./cover.png` / `img/a.png` / `../x.png`) は URL 解決で `./` `../` を畳んでから
+ * `/api/v1/notes/<slug>/assets/<path>` にする。
  */
 export function resolveAssetUrl(slug: string, url: string): string {
-  const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(url);
-  if (isAbsolute || url.startsWith("/")) return url;
-  const clean = url.replace(/^\.\//, "");
-  return `/api/v1/notes/${slug}/assets/${clean}`;
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(url);
+  if (hasScheme || url.startsWith("/")) return url;
+
+  // ダミーオリジン + アセットベースに対して相対解決し、pathname だけ取り出す。
+  // これで "./" は畳まれ、"assets/../x" のような壊れたパスにならない。
+  const base = `https://note.invalid/api/v1/notes/${slug}/assets/`;
+  return new URL(url, base).pathname;
 }

--- a/app/backend/services/note-asset-url.ts
+++ b/app/backend/services/note-asset-url.ts
@@ -1,0 +1,11 @@
+/**
+ * ノート内の相対的な画像 URL をアセット API URL (ルート相対) に解決する。
+ * 絶対 URL (http/https) やルート相対 (`/...`) は解決済みとみなしそのまま返す。
+ * 相対パス (`./cover.png` / `cover.png`) を `/api/v1/notes/<slug>/assets/<path>` にする。
+ */
+export function resolveAssetUrl(slug: string, url: string): string {
+  const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(url);
+  if (isAbsolute || url.startsWith("/")) return url;
+  const clean = url.replace(/^\.\//, "");
+  return `/api/v1/notes/${slug}/assets/${clean}`;
+}

--- a/app/backend/services/note-content-parser.test.ts
+++ b/app/backend/services/note-content-parser.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { extractSummary, parseNoteContent } from "./note-content-parser";
+
+const withFrontmatter = `---
+title: My Note
+imageUrl: ./cover.png
+publishedOn: 2026-01-15
+lastModifiedOn: 2026-01-20
+---
+
+# Heading
+
+First paragraph body.
+
+Second paragraph.
+`;
+
+describe("parseNoteContent", () => {
+  it("extracts frontmatter fields", () => {
+    const { frontmatter } = parseNoteContent(withFrontmatter);
+    expect(frontmatter).toEqual({
+      title: "My Note",
+      imageUrl: "./cover.png",
+      publishedOn: "2026-01-15",
+      lastModifiedOn: "2026-01-20",
+    });
+  });
+
+  it("parses the body (without frontmatter) into MDAST", () => {
+    const { mdast } = parseNoteContent(withFrontmatter);
+    // 先頭は yaml ノードではなく heading (フロントマターは除去済み)。
+    expect(mdast.children.at(0)?.type).toBe("heading");
+  });
+
+  it("derives a summary from body text, skipping headings", () => {
+    const { summary } = parseNoteContent(withFrontmatter);
+    expect(summary.startsWith("First paragraph body.")).toBe(true);
+    expect(summary).not.toContain("Heading");
+  });
+
+  it("returns undefined frontmatter fields when absent", () => {
+    const { frontmatter } = parseNoteContent("# Just a title\n\nBody.");
+    expect(frontmatter.title).toBeUndefined();
+    expect(frontmatter.publishedOn).toBeUndefined();
+  });
+});
+
+describe("extractSummary", () => {
+  it("caps the summary at 160 characters", () => {
+    const long = "a ".repeat(200);
+    const { mdast } = parseNoteContent(long);
+    expect(extractSummary(mdast).length).toBeLessThanOrEqual(160);
+  });
+
+  it("skips code blocks and footnote definitions", () => {
+    const { mdast } = parseNoteContent(
+      "```ts\nconst x = 1;\n```\n\nProse text here.\n",
+    );
+    expect(extractSummary(mdast)).toBe("Prose text here.");
+  });
+});

--- a/app/backend/services/note-content-parser.ts
+++ b/app/backend/services/note-content-parser.ts
@@ -1,0 +1,93 @@
+import { toString as mdastToString } from "mdast-util-to-string";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { matter } from "vfile-matter";
+import type { Root, RootContent } from "mdast";
+
+const SUMMARY_MAX_CHARS = 160;
+
+const markdownProcessor = unified().use(remarkParse).use(remarkGfm);
+
+/** フロントマターから取り出した生のメタデータ (検証前)。 */
+export interface NoteFrontmatter {
+  readonly title: string | undefined;
+  readonly imageUrl: string | undefined;
+  readonly publishedOn: string | undefined;
+  readonly lastModifiedOn: string | undefined;
+}
+
+export interface ParsedNoteContent {
+  readonly frontmatter: NoteFrontmatter;
+  /** フロントマターを除いた本文の MDAST。 */
+  readonly mdast: Root;
+  /** 見出し・脚注を除いた本文先頭 160 文字の要約。 */
+  readonly summary: string;
+}
+
+/**
+ * Markdown を解析してフロントマター・MDAST・要約に分解する。
+ * フロントマターは vfile-matter で抽出・除去し、残りの本文を MDAST に変換する。
+ */
+export function parseNoteContent(markdown: string): ParsedNoteContent {
+  const file = new VFile({ value: markdown });
+  matter(file, { strip: true });
+  const rawMatter = (file.data.matter ?? {}) as Record<string, unknown>;
+
+  const mdast = markdownProcessor.parse(file);
+
+  return {
+    frontmatter: {
+      title: asOptionalString(rawMatter.title),
+      imageUrl: asOptionalString(rawMatter.imageUrl),
+      publishedOn: asDateString(rawMatter.publishedOn),
+      lastModifiedOn: asDateString(rawMatter.lastModifiedOn),
+    },
+    mdast,
+    summary: extractSummary(mdast),
+  };
+}
+
+/**
+ * 見出し・脚注定義・水平線を除いた本文ブロックのテキストを連結し、先頭 160 文字を返す。
+ */
+export function extractSummary(root: Root): string {
+  const parts: string[] = [];
+  for (const node of root.children) {
+    if (!isSummaryNode(node)) continue;
+    const text = mdastToString(node).trim();
+    if (text.length > 0) parts.push(text);
+    if (parts.join(" ").length >= SUMMARY_MAX_CHARS) break;
+  }
+  return parts
+    .join(" ")
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .slice(0, SUMMARY_MAX_CHARS);
+}
+
+const excludedFromSummary = new Set<RootContent["type"]>([
+  "heading",
+  "footnoteDefinition",
+  "thematicBreak",
+  "code",
+]);
+
+function isSummaryNode(node: RootContent): boolean {
+  return !excludedFromSummary.has(node.type);
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * フロントマターの日付を ISO 日付文字列にそろえる。YAML パーサが文字列で返す場合と
+ * Date で返す場合の両方に備える。
+ */
+function asDateString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return undefined;
+}

--- a/app/backend/services/note-content-parser.ts
+++ b/app/backend/services/note-content-parser.ts
@@ -54,11 +54,14 @@ export function parseNoteContent(markdown: string): ParsedNoteContent {
  */
 export function extractSummary(root: Root): string {
   const parts: string[] = [];
+  let length = 0;
   for (const node of root.children) {
     if (!isSummaryNode(node)) continue;
     const text = mdastToString(node).trim();
-    if (text.length > 0) parts.push(text);
-    if (parts.join(" ").length >= SUMMARY_MAX_CHARS) break;
+    if (text.length === 0) continue;
+    parts.push(text);
+    length += text.length + 1; // 連結時の区切りスペース分
+    if (length >= SUMMARY_MAX_CHARS) break;
   }
   return parts
     .join(" ")

--- a/app/backend/services/notes-refresh.service.test.ts
+++ b/app/backend/services/notes-refresh.service.test.ts
@@ -104,7 +104,8 @@ describe("NotesRefreshService", () => {
     expect(note?.imageUrl?.toString()).toBe(
       "/api/v1/notes/hello/assets/cover.png",
     );
-    expect(note?.sourceHash).toBe("h1");
+    // sourceHash は md + アセットの合成ハッシュ (生の blob ハッシュではない)。
+    expect(note?.sourceHash).toMatch(/^[0-9a-f]{8}$/);
     expect(note?.summary).toContain("Body with an inline image");
 
     // アセットが R2 キャッシュに入る。
@@ -168,5 +169,50 @@ describe("NotesRefreshService", () => {
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0].path).toBe("notes/bad.md");
     expect(await query.findBySlug(NoteSlug.create("bad"))).toBeUndefined();
+  });
+
+  it("reprocesses when only an asset changes (image-only edit)", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+      ["notes/hello/cover.png", { hash: "a1", bytes: bytes("v1") }],
+    ]);
+    const { service } = setup(files);
+
+    await service.refresh();
+    // .md は据え置きで画像だけ差し替える。
+    files.set("notes/hello/cover.png", { hash: "a2", bytes: bytes("v2") });
+    const second = await service.refresh();
+    expect(second.processed).toEqual(["hello"]);
+  });
+
+  it("prunes assets that were removed or renamed", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+      ["notes/hello/old.png", { hash: "a1", bytes: bytes("old") }],
+    ]);
+    const { service, cache } = setup(files);
+
+    await service.refresh();
+    expect(cache.assets.has("hello::old.png")).toBe(true);
+
+    // old.png を new.png にリネーム (+ .md も更新して再処理させる)。
+    files.delete("notes/hello/old.png");
+    files.set("notes/hello/new.png", { hash: "a2", bytes: bytes("new") });
+    files.set("notes/hello.md", { hash: "h2", bytes: bytes(helloMd) });
+    await service.refresh();
+
+    expect(cache.assets.has("hello::old.png")).toBe(false);
+    expect(cache.assets.has("hello::new.png")).toBe(true);
+  });
+
+  it("propagates infra errors (fail-loud) instead of skipping them", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+    ]);
+    const { service, cache } = setup(files);
+    // R2 書き込みが落ちる状況を再現する。
+    cache.putMdast = () => Promise.reject(new Error("R2 down"));
+
+    await expect(service.refresh()).rejects.toThrow("R2 down");
   });
 });

--- a/app/backend/services/notes-refresh.service.test.ts
+++ b/app/backend/services/notes-refresh.service.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { NotesRefreshService } from "./notes-refresh.service";
+import type { ContentEntry, IContentStore } from "~/backend/domain/content";
+import type { CachedAsset, INoteContentCache } from "~/backend/domain/note";
+import { NoteSlug } from "~/backend/domain/note";
+import {
+  D1NoteCommandRepository,
+  D1NoteQueryRepository,
+} from "~/backend/infra/d1/repositories";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+class MockContentStore implements IContentStore {
+  constructor(
+    private readonly files: Map<string, { hash: string; bytes: Uint8Array }>,
+  ) {}
+
+  listTree(): Promise<readonly ContentEntry[]> {
+    return Promise.resolve(
+      [...this.files].map(([path, { hash }]) => ({ path, hash })),
+    );
+  }
+
+  readFile(path: string): Promise<Uint8Array | undefined> {
+    return Promise.resolve(this.files.get(path)?.bytes);
+  }
+}
+
+class InMemoryCache implements INoteContentCache {
+  readonly mdasts = new Map<string, unknown>();
+  readonly assets = new Map<string, CachedAsset>();
+
+  putMdast(slug: NoteSlug, mdast: unknown): Promise<void> {
+    this.mdasts.set(slug.toString(), mdast);
+    return Promise.resolve();
+  }
+  getMdast(slug: NoteSlug): Promise<unknown> {
+    return Promise.resolve(this.mdasts.get(slug.toString()));
+  }
+  putAsset(slug: NoteSlug, path: string, asset: CachedAsset): Promise<void> {
+    this.assets.set(`${slug.toString()}::${path}`, asset);
+    return Promise.resolve();
+  }
+  getAsset(slug: NoteSlug, path: string): Promise<CachedAsset | undefined> {
+    return Promise.resolve(this.assets.get(`${slug.toString()}::${path}`));
+  }
+  deleteNote(slug: NoteSlug): Promise<void> {
+    this.mdasts.delete(slug.toString());
+    const prefix = `${slug.toString()}::`;
+    for (const key of this.assets.keys()) {
+      if (key.startsWith(prefix)) this.assets.delete(key);
+    }
+    return Promise.resolve();
+  }
+}
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+const helloMd = `---
+title: Hello
+imageUrl: ./cover.png
+publishedOn: 2026-01-15
+lastModifiedOn: 2026-01-16
+---
+
+Body with an inline image ![alt](./inline.png).
+`;
+
+function setup(files: Map<string, { hash: string; bytes: Uint8Array }>): {
+  service: NotesRefreshService;
+  command: D1NoteCommandRepository;
+  query: D1NoteQueryRepository;
+  cache: InMemoryCache;
+} {
+  const d1 = createTestD1();
+  const command = new D1NoteCommandRepository(d1);
+  const query = new D1NoteQueryRepository(d1);
+  const cache = new InMemoryCache();
+  const service = new NotesRefreshService(
+    new MockContentStore(files),
+    command,
+    query,
+    cache,
+  );
+  return { service, command, query, cache };
+}
+
+describe("NotesRefreshService", () => {
+  it("indexes a note, caches its MDAST and assets, resolves image URLs", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+      ["notes/hello/cover.png", { hash: "a1", bytes: bytes("PNG") }],
+      ["notes/hello/inline.png", { hash: "a2", bytes: bytes("PNG2") }],
+    ]);
+    const { service, query, cache } = setup(files);
+
+    const result = await service.refresh();
+    expect(result.processed).toEqual(["hello"]);
+    expect(result.skipped).toEqual([]);
+
+    const note = await query.findBySlug(NoteSlug.create("hello"));
+    expect(note?.title.toString()).toBe("Hello");
+    expect(note?.imageUrl?.toString()).toBe(
+      "/api/v1/notes/hello/assets/cover.png",
+    );
+    expect(note?.sourceHash).toBe("h1");
+    expect(note?.summary).toContain("Body with an inline image");
+
+    // アセットが R2 キャッシュに入る。
+    expect(cache.assets.has("hello::cover.png")).toBe(true);
+    expect(cache.assets.has("hello::inline.png")).toBe(true);
+
+    // 本文 MDAST の画像 URL がアセット API URL に解決されている。
+    const mdastJson = JSON.stringify(cache.mdasts.get("hello"));
+    expect(mdastJson).toContain("/api/v1/notes/hello/assets/inline.png");
+  });
+
+  it("skips unchanged notes on a second refresh (hash match)", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+    ]);
+    const { service } = setup(files);
+
+    await service.refresh();
+    const second = await service.refresh();
+    expect(second.processed).toEqual([]);
+  });
+
+  it("reprocesses a note when its hash changes", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+    ]);
+    const { service } = setup(files);
+
+    await service.refresh();
+    files.set("notes/hello.md", { hash: "h2", bytes: bytes(helloMd) });
+    const second = await service.refresh();
+    expect(second.processed).toEqual(["hello"]);
+  });
+
+  it("deletes notes removed from the tree", async () => {
+    const files = new Map([
+      ["notes/hello.md", { hash: "h1", bytes: bytes(helloMd) }],
+    ]);
+    const { service, query, cache } = setup(files);
+
+    await service.refresh();
+    files.delete("notes/hello.md");
+    const result = await service.refresh();
+
+    expect(result.deleted).toEqual(["hello"]);
+    expect(await query.findBySlug(NoteSlug.create("hello"))).toBeUndefined();
+    expect(cache.mdasts.has("hello")).toBe(false);
+  });
+
+  it("skips notes with invalid frontmatter (missing publishedOn)", async () => {
+    const files = new Map([
+      [
+        "notes/bad.md",
+        { hash: "b1", bytes: bytes("---\ntitle: Bad\n---\n\nBody.\n") },
+      ],
+    ]);
+    const { service, query } = setup(files);
+
+    const result = await service.refresh();
+    expect(result.processed).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].path).toBe("notes/bad.md");
+    expect(await query.findBySlug(NoteSlug.create("bad"))).toBeUndefined();
+  });
+});

--- a/app/backend/services/notes-refresh.service.ts
+++ b/app/backend/services/notes-refresh.service.ts
@@ -1,0 +1,191 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { contentTypeForPath } from "./asset-content-type";
+import { resolveAssetUrl } from "./note-asset-url";
+import { parseNoteContent } from "./note-content-parser";
+import type { ContentEntry, IContentStore } from "~/backend/domain/content";
+import type {
+  INoteCommandRepository,
+  INoteContentCache,
+  INoteQueryRepository,
+} from "~/backend/domain/note";
+import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+
+const noteSourcePattern = /^notes\/[^/]+\.md$/;
+
+/** refresh の実行結果サマリ。 */
+export interface RefreshResult {
+  /** 再処理した slug。 */
+  readonly processed: string[];
+  /** 削除した slug (Artifacts から消えたノート)。 */
+  readonly deleted: string[];
+  /** 不正なフロントマター等でスキップしたファイル。 */
+  readonly skipped: { path: string; reason: string }[];
+}
+
+interface NoteGroup {
+  readonly slug: NoteSlug;
+  readonly base: string;
+  readonly sourcePath: string;
+  readonly hash: string;
+  readonly assets: readonly ContentEntry[];
+}
+
+/**
+ * Artifacts → D1 + R2 のコンテンツ同期サービス。
+ *
+ * ツリーを取得し blob ハッシュで変更を検出、変わったノートだけ内容を読み直して
+ * MDAST を R2 にキャッシュ・メタデータを D1 に upsert・画像を R2 にキャッシュする。
+ * Artifacts から消えたノートは D1 / R2 から掃除する (ADR 0005)。
+ */
+export class NotesRefreshService {
+  constructor(
+    private readonly content: IContentStore,
+    private readonly command: INoteCommandRepository,
+    private readonly query: INoteQueryRepository,
+    private readonly cache: INoteContentCache,
+  ) {}
+
+  async refresh(): Promise<RefreshResult> {
+    const tree = await this.content.listTree();
+    const groups = this.groupNotes(tree);
+    const stored = await this.query.listSourceHashes();
+
+    const processed: string[] = [];
+    const skipped: { path: string; reason: string }[] = [];
+    const seen = new Set<string>();
+
+    for (const group of groups) {
+      const slug = group.slug.toString();
+      seen.add(slug);
+      if (stored.get(slug) === group.hash) continue; // 変更なし
+      try {
+        await this.processNote(group);
+        processed.push(slug);
+      } catch (error) {
+        skipped.push({
+          path: group.sourcePath,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const deleted = await this.deleteRemoved(stored, seen);
+    return { processed, deleted, skipped };
+  }
+
+  /** ツリーをノード単位 (slug) にまとめる。不正な slug の .md は無視する。 */
+  private groupNotes(tree: readonly ContentEntry[]): NoteGroup[] {
+    const groups: NoteGroup[] = [];
+    for (const entry of tree) {
+      if (!noteSourcePattern.test(entry.path)) continue;
+      const base = entry.path.slice("notes/".length, -".md".length);
+      let slug: NoteSlug;
+      try {
+        slug = NoteSlug.create(base);
+      } catch {
+        continue; // slug にできないファイル名は対象外
+      }
+      const assetPrefix = `notes/${base}/`;
+      const assets = tree.filter((e) => e.path.startsWith(assetPrefix));
+      groups.push({
+        slug,
+        base,
+        sourcePath: entry.path,
+        hash: entry.hash,
+        assets,
+      });
+    }
+    return groups;
+  }
+
+  private async processNote(group: NoteGroup): Promise<void> {
+    const bytes = await this.content.readFile(group.sourcePath);
+    if (bytes === undefined) {
+      throw new Error("source file could not be read");
+    }
+    const parsed = parseNoteContent(new TextDecoder().decode(bytes));
+    const slug = group.slug.toString();
+
+    const publishedRaw = parsed.frontmatter.publishedOn;
+    if (publishedRaw === undefined) {
+      throw new Error("frontmatter is missing publishedOn");
+    }
+    const publishedOn = Temporal.PlainDate.from(publishedRaw);
+    const lastModifiedOn = Temporal.PlainDate.from(
+      parsed.frontmatter.lastModifiedOn ?? publishedRaw,
+    );
+
+    const imageUrl =
+      parsed.frontmatter.imageUrl === undefined
+        ? undefined
+        : ImageUrl.create(resolveAssetUrl(slug, parsed.frontmatter.imageUrl));
+
+    // 本文中の相対画像 URL をアセット API URL に解決してからキャッシュする (ADR 0006)。
+    resolveMdastImageUrls(parsed.mdast, slug);
+    await this.cache.putMdast(group.slug, parsed.mdast);
+    await this.cacheAssets(group);
+
+    await this.command.upsert(
+      Note.create({
+        slug: group.slug,
+        title: NoteTitle.create(parsed.frontmatter.title ?? group.base),
+        summary: parsed.summary,
+        imageUrl,
+        publishedOn,
+        lastModifiedOn,
+        sourceHash: group.hash,
+      }),
+    );
+  }
+
+  private async cacheAssets(group: NoteGroup): Promise<void> {
+    const prefix = `notes/${group.base}/`;
+    for (const asset of group.assets) {
+      const bytes = await this.content.readFile(asset.path);
+      if (bytes === undefined) continue;
+      const relPath = asset.path.slice(prefix.length);
+      await this.cache.putAsset(group.slug, relPath, {
+        bytes,
+        contentType: contentTypeForPath(relPath),
+      });
+    }
+  }
+
+  private async deleteRemoved(
+    stored: ReadonlyMap<string, string>,
+    seen: ReadonlySet<string>,
+  ): Promise<string[]> {
+    const deleted: string[] = [];
+    for (const slug of stored.keys()) {
+      if (seen.has(slug)) continue;
+      const noteSlug = NoteSlug.create(slug);
+      await this.command.deleteBySlug(noteSlug);
+      await this.cache.deleteNote(noteSlug);
+      deleted.push(slug);
+    }
+    return deleted;
+  }
+}
+
+interface MdastNodeLike {
+  type: string;
+  url?: string;
+  children?: MdastNodeLike[];
+}
+
+/** MDAST を走査し image / definition の相対 URL をアセット API URL に書き換える。 */
+export function resolveMdastImageUrls(node: unknown, slug: string): void {
+  if (typeof node !== "object" || node === null) return;
+  const record = node as MdastNodeLike;
+  if (
+    (record.type === "image" || record.type === "definition") &&
+    typeof record.url === "string"
+  ) {
+    record.url = resolveAssetUrl(slug, record.url);
+  }
+  if (Array.isArray(record.children)) {
+    for (const child of record.children) {
+      resolveMdastImageUrls(child, slug);
+    }
+  }
+}

--- a/app/backend/services/notes-refresh.service.ts
+++ b/app/backend/services/notes-refresh.service.ts
@@ -8,6 +8,7 @@ import type {
   INoteContentCache,
   INoteQueryRepository,
 } from "~/backend/domain/note";
+import type { IUnpersisted } from "~/backend/domain/shared";
 import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
 
 const noteSourcePattern = /^notes\/[^/]+\.md$/;
@@ -18,7 +19,7 @@ export interface RefreshResult {
   readonly processed: string[];
   /** 削除した slug (Artifacts から消えたノート)。 */
   readonly deleted: string[];
-  /** 不正なフロントマター等でスキップしたファイル。 */
+  /** 不正なコンテンツ (フロントマター等) でスキップしたファイル。 */
   readonly skipped: { path: string; reason: string }[];
 }
 
@@ -26,16 +27,26 @@ interface NoteGroup {
   readonly slug: NoteSlug;
   readonly base: string;
   readonly sourcePath: string;
-  readonly hash: string;
+  readonly assetPrefix: string;
   readonly assets: readonly ContentEntry[];
+  /** md + 全アセットのハッシュを合成した変更検出用ハッシュ。 */
+  readonly contentHash: string;
+}
+
+/** コンテンツ由来のエラー (フロントマター不正等)。infra エラーと区別してスキップ扱いにする。 */
+class NoteContentError extends Error {
+  readonly name = "NoteContentError";
 }
 
 /**
  * Artifacts → D1 + R2 のコンテンツ同期サービス。
  *
- * ツリーを取得し blob ハッシュで変更を検出、変わったノートだけ内容を読み直して
- * MDAST を R2 にキャッシュ・メタデータを D1 に upsert・画像を R2 にキャッシュする。
- * Artifacts から消えたノートは D1 / R2 から掃除する (ADR 0005)。
+ * ツリーを取得し、md + アセットの合成ハッシュで変更を検出、変わったノートだけ内容を
+ * 読み直して MDAST を R2 にキャッシュ・メタデータを D1 に upsert・画像を R2 にキャッシュ
+ * する。Artifacts から消えたノートは D1 / R2 から掃除する (ADR 0005)。
+ *
+ * コンテンツ不正 (フロントマター欠落等) はスキップして結果に記録するが、infra 障害
+ * (Artifacts / R2 / D1) は握りつぶさず throw する (fail-loud)。
  */
 export class NotesRefreshService {
   constructor(
@@ -47,7 +58,7 @@ export class NotesRefreshService {
 
   async refresh(): Promise<RefreshResult> {
     const tree = await this.content.listTree();
-    const groups = this.groupNotes(tree);
+    const groups = groupNotes(tree);
     const stored = await this.query.listSourceHashes();
 
     const processed: string[] = [];
@@ -57,15 +68,17 @@ export class NotesRefreshService {
     for (const group of groups) {
       const slug = group.slug.toString();
       seen.add(slug);
-      if (stored.get(slug) === group.hash) continue; // 変更なし
+      if (stored.get(slug) === group.contentHash) continue; // 変更なし
       try {
-        await this.processNote(group);
+        await this.syncNote(group);
         processed.push(slug);
       } catch (error) {
-        skipped.push({
-          path: group.sourcePath,
-          reason: error instanceof Error ? error.message : String(error),
-        });
+        // コンテンツ不正はスキップ。infra 障害はここで握りつぶさず再送出する。
+        if (error instanceof NoteContentError) {
+          skipped.push({ path: group.sourcePath, reason: error.message });
+          continue;
+        }
+        throw error;
       }
     }
 
@@ -73,77 +86,33 @@ export class NotesRefreshService {
     return { processed, deleted, skipped };
   }
 
-  /** ツリーをノード単位 (slug) にまとめる。不正な slug の .md は無視する。 */
-  private groupNotes(tree: readonly ContentEntry[]): NoteGroup[] {
-    const groups: NoteGroup[] = [];
-    for (const entry of tree) {
-      if (!noteSourcePattern.test(entry.path)) continue;
-      const base = entry.path.slice("notes/".length, -".md".length);
-      let slug: NoteSlug;
-      try {
-        slug = NoteSlug.create(base);
-      } catch {
-        continue; // slug にできないファイル名は対象外
-      }
-      const assetPrefix = `notes/${base}/`;
-      const assets = tree.filter((e) => e.path.startsWith(assetPrefix));
-      groups.push({
-        slug,
-        base,
-        sourcePath: entry.path,
-        hash: entry.hash,
-        assets,
-      });
-    }
-    return groups;
-  }
-
-  private async processNote(group: NoteGroup): Promise<void> {
+  /**
+   * 1 ノートを同期する。まず読み取り・検証を済ませ (この間の失敗は content or infra
+   * エラーとして送出)、成功したら古いキャッシュを消してから MDAST・アセット・メタデータを
+   * 書き込む。D1 upsert を最後に置くことで、途中失敗時も次回 refresh で再処理される。
+   */
+  private async syncNote(group: NoteGroup): Promise<void> {
     const bytes = await this.content.readFile(group.sourcePath);
     if (bytes === undefined) {
-      throw new Error("source file could not be read");
+      // ツリーには在るのに読めない = infra 障害。fail-loud で送出。
+      throw new Error(`source file could not be read: ${group.sourcePath}`);
     }
-    const parsed = parseNoteContent(new TextDecoder().decode(bytes));
-    const slug = group.slug.toString();
 
-    const publishedRaw = parsed.frontmatter.publishedOn;
-    if (publishedRaw === undefined) {
-      throw new Error("frontmatter is missing publishedOn");
-    }
-    const publishedOn = Temporal.PlainDate.from(publishedRaw);
-    const lastModifiedOn = Temporal.PlainDate.from(
-      parsed.frontmatter.lastModifiedOn ?? publishedRaw,
-    );
+    // 検証込みでエンティティと MDAST を組み立てる (不正なら NoteContentError)。
+    const { note, mdast } = buildNoteContent(group, bytes);
 
-    const imageUrl =
-      parsed.frontmatter.imageUrl === undefined
-        ? undefined
-        : ImageUrl.create(resolveAssetUrl(slug, parsed.frontmatter.imageUrl));
-
-    // 本文中の相対画像 URL をアセット API URL に解決してからキャッシュする (ADR 0006)。
-    resolveMdastImageUrls(parsed.mdast, slug);
-    await this.cache.putMdast(group.slug, parsed.mdast);
+    // 古いキャッシュ (リネーム・削除されたアセット含む) を消してから書き直す。
+    await this.cache.deleteNote(group.slug);
+    await this.cache.putMdast(group.slug, mdast);
     await this.cacheAssets(group);
-
-    await this.command.upsert(
-      Note.create({
-        slug: group.slug,
-        title: NoteTitle.create(parsed.frontmatter.title ?? group.base),
-        summary: parsed.summary,
-        imageUrl,
-        publishedOn,
-        lastModifiedOn,
-        sourceHash: group.hash,
-      }),
-    );
+    await this.command.upsert(note);
   }
 
   private async cacheAssets(group: NoteGroup): Promise<void> {
-    const prefix = `notes/${group.base}/`;
     for (const asset of group.assets) {
       const bytes = await this.content.readFile(asset.path);
       if (bytes === undefined) continue;
-      const relPath = asset.path.slice(prefix.length);
+      const relPath = asset.path.slice(group.assetPrefix.length);
       await this.cache.putAsset(group.slug, relPath, {
         bytes,
         contentType: contentTypeForPath(relPath),
@@ -167,25 +136,172 @@ export class NotesRefreshService {
   }
 }
 
+/**
+ * ツリーを 1 パスでノード単位 (slug) にまとめる。`notes/<base>.md` を起点にし、
+ * `notes/<base>/` 配下のエントリをそのアセットとして束ねる。合成ハッシュも算出する。
+ */
+function groupNotes(tree: readonly ContentEntry[]): NoteGroup[] {
+  const sources: { base: string; entry: ContentEntry }[] = [];
+  const assetsByPrefix = new Map<string, ContentEntry[]>();
+
+  for (const entry of tree) {
+    if (noteSourcePattern.test(entry.path)) {
+      sources.push({
+        base: entry.path.slice("notes/".length, -".md".length),
+        entry,
+      });
+    } else if (entry.path.startsWith("notes/")) {
+      const prefixEnd = entry.path.indexOf("/", "notes/".length);
+      if (prefixEnd === -1) continue;
+      const prefix = entry.path.slice(0, prefixEnd + 1);
+      const list = assetsByPrefix.get(prefix) ?? [];
+      list.push(entry);
+      assetsByPrefix.set(prefix, list);
+    }
+  }
+
+  const groups: NoteGroup[] = [];
+  for (const { base, entry } of sources) {
+    let slug: NoteSlug;
+    try {
+      slug = NoteSlug.create(base);
+    } catch {
+      continue; // slug にできないファイル名は対象外
+    }
+    const assetPrefix = `notes/${base}/`;
+    const assets = assetsByPrefix.get(assetPrefix) ?? [];
+    groups.push({
+      slug,
+      base,
+      sourcePath: entry.path,
+      assetPrefix,
+      assets,
+      contentHash: computeContentHash(entry, assets),
+    });
+  }
+  return groups;
+}
+
+/** md + アセットの (path, hash) を合成した変更検出用ハッシュ。 */
+function computeContentHash(
+  source: ContentEntry,
+  assets: readonly ContentEntry[],
+): string {
+  const sortedAssets = assets.toSorted((a, b) => a.path.localeCompare(b.path));
+  const parts = [`${source.path}:${source.hash}`];
+  for (const asset of sortedAssets) {
+    parts.push(`${asset.path}:${asset.hash}`);
+  }
+  return fnv1a(parts.join("\n"));
+}
+
+/** FNV-1a 32-bit ハッシュ (16 進)。変更検出用途に十分。 */
+function fnv1a(input: string): string {
+  let hash = 0x81_1c_9d_c5;
+  for (const ch of input) {
+    hash ^= ch.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01_00_01_93);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * バイト列から Note エンティティと MDAST を組み立てる純関数。
+ * 不正なフロントマター・VO 検証失敗は {@link NoteContentError} として送出する。
+ */
+function buildNoteContent(
+  group: NoteGroup,
+  bytes: Uint8Array,
+): { note: Note<IUnpersisted>; mdast: unknown } {
+  const parsed = parseNoteContent(new TextDecoder().decode(bytes));
+  const slug = group.slug.toString();
+
+  const publishedRaw = parsed.frontmatter.publishedOn;
+  if (publishedRaw === undefined) {
+    throw new NoteContentError("frontmatter is missing publishedOn");
+  }
+
+  try {
+    const publishedOn = Temporal.PlainDate.from(publishedRaw);
+    const lastModifiedOn = Temporal.PlainDate.from(
+      parsed.frontmatter.lastModifiedOn ?? publishedRaw,
+    );
+    const imageUrl =
+      parsed.frontmatter.imageUrl === undefined
+        ? undefined
+        : ImageUrl.create(resolveAssetUrl(slug, parsed.frontmatter.imageUrl));
+    const note = Note.create({
+      slug: group.slug,
+      title: NoteTitle.create(parsed.frontmatter.title ?? group.base),
+      summary: parsed.summary,
+      imageUrl,
+      publishedOn,
+      lastModifiedOn,
+      sourceHash: group.contentHash,
+    });
+
+    // 本文中の相対画像 URL をアセット API URL に解決してからキャッシュする (ADR 0006)。
+    resolveMdastImageUrls(parsed.mdast, slug);
+    return { note, mdast: parsed.mdast };
+  } catch (error) {
+    if (error instanceof NoteContentError) throw error;
+    // VO 検証・日付パース失敗はコンテンツ不正として扱う。
+    throw new NoteContentError(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
 interface MdastNodeLike {
   type: string;
   url?: string;
+  identifier?: string;
   children?: MdastNodeLike[];
 }
 
-/** MDAST を走査し image / definition の相対 URL をアセット API URL に書き換える。 */
+/**
+ * MDAST を走査し、画像の相対 URL をアセット API URL に書き換える。
+ * `image` ノードと、`imageReference` から参照される `definition` のみを対象にし、
+ * リンク参照 (linkReference) の definition は書き換えない。
+ */
 export function resolveMdastImageUrls(node: unknown, slug: string): void {
+  const imageRefIds = new Set<string>();
+  collectImageReferenceIds(node, imageRefIds);
+  rewriteImageUrls(node, slug, imageRefIds);
+}
+
+function collectImageReferenceIds(node: unknown, ids: Set<string>): void {
   if (typeof node !== "object" || node === null) return;
   const record = node as MdastNodeLike;
   if (
-    (record.type === "image" || record.type === "definition") &&
-    typeof record.url === "string"
+    record.type === "imageReference" &&
+    typeof record.identifier === "string"
   ) {
+    ids.add(record.identifier);
+  }
+  if (Array.isArray(record.children)) {
+    for (const child of record.children) collectImageReferenceIds(child, ids);
+  }
+}
+
+function rewriteImageUrls(
+  node: unknown,
+  slug: string,
+  imageRefIds: ReadonlySet<string>,
+): void {
+  if (typeof node !== "object" || node === null) return;
+  const record = node as MdastNodeLike;
+  const isImage = record.type === "image";
+  const isImageDefinition =
+    record.type === "definition" &&
+    typeof record.identifier === "string" &&
+    imageRefIds.has(record.identifier);
+  if ((isImage || isImageDefinition) && typeof record.url === "string") {
     record.url = resolveAssetUrl(slug, record.url);
   }
   if (Array.isArray(record.children)) {
     for (const child of record.children) {
-      resolveMdastImageUrls(child, slug);
+      rewriteImageUrls(child, slug, imageRefIds);
     }
   }
 }

--- a/docs/adr/0007-artifacts-read-via-binding-token-and-rest.md
+++ b/docs/adr/0007-artifacts-read-via-binding-token-and-rest.md
@@ -1,0 +1,62 @@
+# 0007. Artifacts のファイル読み取りは binding 発行トークン + REST API で行う
+
+- Status: Accepted
+- Date: 2026-07-05
+- Deciders: @yantene
+
+## Context / 背景
+
+[0005](0005-artifacts-as-content-source-of-truth.md) では、refresh 時に
+「Binding の `readTree` でツリーを取得し、変更ファイルだけ REST API で内容を取得する」
+と記した。しかし実装時点 (wrangler 4.107) の Artifacts Workers binding
+(`interface Artifacts`) が公開するのはリポジトリ管理系メソッド
+(`create` / `get` / `import` / `list` / `delete`) と、`ArtifactsRepo.createToken`
+によるアクセストークン発行のみで、**ファイル内容やツリーを binding から直接読む
+メソッド (`readTree` / `readBlob`) は存在しない**。
+
+したがって「binding でツリー・内容を読む」という 0005 の実装詳細はそのままでは成立せず、
+実際に使える API に合わせて読み取り経路を定め直す必要がある。
+
+## 検討した選択肢
+
+- **案 A: アカウント API トークンを secret に置き REST を叩く** — `CLOUDFLARE_API_TOKEN`
+  相当をワーカーの secret として持ち、Bearer で Artifacts REST API を呼ぶ。
+  - Pros: ドキュメントの REST 認証例と一致。実装が単純。
+  - Cons: アカウント全体を操作できる強い API トークンをワーカーに常駐させる。
+    secure by default に反する。
+- **案 B: binding で repo スコープの read トークンを発行し REST を叩く** — refresh 時に
+  `ARTIFACTS.get(repo).createToken("read")` で短命・読み取り専用・リポジトリ限定の
+  トークンを発行し、それを Bearer に載せて REST API でツリー・ファイルを読む。
+  - Pros: 権限最小化 (read only・repo 限定・短命)。binding を素直に活かす。
+  - Cons: リクエストごと (または一定間隔) にトークン発行の往復が要る。REST の
+    レスポンス形状が beta で不確定。
+
+## 決定
+
+案 B を採用する。0005 の「Artifacts を source of truth、D1/R2 をキャッシュ、blob
+ハッシュで変更検出」という骨子は維持したまま、**読み取り経路のみ**を次のように定める。
+
+- ドメインは技術非依存の `IContentStore` (`listTree()` / `readFile(path)`) を定義する。
+- infra の `ArtifactsContentStore` が実装し、Artifacts binding で発行した read トークンを
+  Bearer に載せて REST API を呼ぶ。
+  - ツリー: `GET /accounts/:acct/artifacts/namespaces/:ns/repos/:repo/tree/:ref`
+  - ファイル: `GET /accounts/:acct/artifacts/namespaces/:ns/repos/:repo/file?ref=&path=`
+- 変更検出は 0005 通り、ツリーが返す各ファイルのハッシュを D1 の保存済みと比較する。
+- accountId は secret (`ARTIFACTS_ACCOUNT_ID`)、namespace / repo / branch は wrangler の
+  vars で与える。未設定時は静かに劣化させず fail-loud で throw する。
+
+## 帰結 / Consequences
+
+- 良い面: 権限最小のトークンで読み取れる。ドメインは Artifacts を知らないまま
+  (`IContentStore`)、実装差し替えが効く。0005 の設計意図を壊さない。
+- 悪い面・トレードオフ: REST レスポンス (特に tree の JSON 形状) が beta のため未確定で、
+  実 API との突き合わせで解析の微修正が要る可能性がある。解析は
+  `parseTreeResponse` に隔離し、そこだけ直せば済むようにしてある。
+- 検証方法: `ArtifactsContentStore` を fetch モックでユニットテストする。実 Artifacts
+  リポジトリを用意でき次第、tree レスポンス形状を突き合わせて `parseTreeResponse` を確定する。
+
+## 参考 / More Information
+
+- [0005](0005-artifacts-as-content-source-of-truth.md)
+- [Cloudflare Artifacts REST API](https://developers.cloudflare.com/artifacts/api/rest-api/)
+- [Cloudflare Artifacts Workers binding](https://developers.cloudflare.com/artifacts/api/workers-binding/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,11 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                               | Status   |
-| ------------------------------------------------------ | ------------------------------------------------------ | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する           | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する          | Accepted |
+| #                                                      | タイトル                                                   | Status   |
+| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
 | [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,11 +9,12 @@
 
 ## 一覧
 
-| #                                                      | タイトル                                                   | Status   |
-| ------------------------------------------------------ | ---------------------------------------------------------- | -------- |
-| [0001](0001-record-architecture-decisions.md)          | アーキテクチャ決定を ADR として記録する                    | Accepted |
-| [0002](0002-value-objects-at-repository-boundaries.md) | リポジトリ境界では Value Object / ブランド型で受け渡す     | Accepted |
-| [0003](0003-clean-architecture-and-cqrs.md)            | Clean Architecture (DIP) と CQRS を採用する                | Accepted |
-| [0004](0004-inertia-server-driven-spa.md)              | Inertia.js によるサーバー駆動 SPA を採用する               | Accepted |
-| [0005](0005-artifacts-as-content-source-of-truth.md)   | Cloudflare Artifacts をコンテンツの source of truth にする | Accepted |
-| [0006](0006-mdast-over-html-rendering.md)              | Markdown を HTML ではなく MDAST でフロントエンドに渡す     | Accepted |
+| #                                                         | タイトル                                                              | Status   |
+| --------------------------------------------------------- | --------------------------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)             | アーキテクチャ決定を ADR として記録する                               | Accepted |
+| [0002](0002-value-objects-at-repository-boundaries.md)    | リポジトリ境界では Value Object / ブランド型で受け渡す                | Accepted |
+| [0003](0003-clean-architecture-and-cqrs.md)               | Clean Architecture (DIP) と CQRS を採用する                           | Accepted |
+| [0004](0004-inertia-server-driven-spa.md)                 | Inertia.js によるサーバー駆動 SPA を採用する                          | Accepted |
+| [0005](0005-artifacts-as-content-source-of-truth.md)      | Cloudflare Artifacts をコンテンツの source of truth にする            | Accepted |
+| [0006](0006-mdast-over-html-rendering.md)                 | Markdown を HTML ではなく MDAST でフロントエンドに渡す                | Accepted |
+| [0007](0007-artifacts-read-via-binding-token-and-rest.md) | Artifacts のファイル読み取りは binding 発行トークン + REST API で行う | Accepted |

--- a/migrations/0001_create_notes_table.sql
+++ b/migrations/0001_create_notes_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `notes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`title` text NOT NULL,
+	`summary` text NOT NULL,
+	`image_url` text,
+	`published_on` text NOT NULL,
+	`last_modified_on` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `notes_slug_unique` ON `notes` (`slug`);

--- a/migrations/0002_add_notes_source_hash.sql
+++ b/migrations/0002_add_notes_source_hash.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `notes` ADD `source_hash` text NOT NULL;
+ALTER TABLE `notes` ADD `source_hash` text DEFAULT '' NOT NULL;

--- a/migrations/0002_add_notes_source_hash.sql
+++ b/migrations/0002_add_notes_source_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `notes` ADD `source_hash` text NOT NULL;

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,148 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "515262b0-5233-4003-a022-dfa0039ad1e7",
+  "prevId": "02defeaf-eeb8-4612-9ac8-b1965a1d4bea",
+  "tables": {
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "e841341e-7c55-4ad1-b16d-12e0e9fcd081",
+  "id": "fd6694ca-26e9-496c-8ed9-96e8acf0cee4",
   "prevId": "515262b0-5233-4003-a022-dfa0039ad1e7",
   "tables": {
     "notes": {
@@ -61,7 +61,8 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "''"
         },
         "created_at": {
           "name": "created_at",

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,155 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e841341e-7c55-4ad1-b16d-12e0e9fcd081",
+  "prevId": "515262b0-5233-4003-a022-dfa0039ad1e7",
+  "tables": {
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783215054973,
       "tag": "0001_create_notes_table",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1783219961733,
+      "tag": "0002_add_notes_source_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -19,7 +19,7 @@
     {
       "idx": 2,
       "version": "6",
-      "when": 1783219961733,
+      "when": 1783223392342,
       "tag": "0002_add_notes_source_hash",
       "breakpoints": true
     }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780567722357,
       "tag": "0000_create_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1783215054973,
+      "tag": "0001_create_notes_table",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -47,10 +47,16 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.27",
     "i18next": "^26.3.4",
+    "mdast-util-to-string": "^4.0.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.8",
-    "react-icons": "^5.7.0"
+    "react-icons": "^5.7.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "vfile": "^6.0.3",
+    "vfile-matter": "^5.0.1"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.43.0",
@@ -65,6 +71,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",
     "@types/eslint-plugin-security": "^3.0.1",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^26",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       i18next:
         specifier: ^26.3.4
         version: 26.3.4(typescript@6.0.3)
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       react:
         specifier: ^19.2.6
         version: 19.2.7
@@ -44,6 +47,21 @@ importers:
       react-icons:
         specifier: ^5.7.0
         version: 5.7.0(react@19.2.7)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vfile-matter:
+        specifier: ^5.0.1
+        version: 5.0.1
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.43.0
@@ -81,6 +99,9 @@ importers:
       '@types/eslint-plugin-security':
         specifier: ^3.0.1
         version: 3.0.1
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^26
         version: 26.1.0
@@ -1648,6 +1669,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1669,6 +1693,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
@@ -1685,6 +1715,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -2076,6 +2109,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2145,6 +2181,9 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2159,6 +2198,9 @@ packages:
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -2229,6 +2271,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2267,6 +2312,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2464,6 +2512,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
@@ -2602,6 +2654,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2866,6 +2921,10 @@ packages:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3064,6 +3123,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3085,9 +3147,129 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3340,6 +3522,15 @@ packages:
     resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3564,6 +3755,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3635,6 +3829,21 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -3655,6 +3864,15 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vfile-matter@5.0.1:
+    resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-ssr-components@0.6.1:
     resolution: {integrity: sha512-KVHI6pYcF3NZ1f6OVUCx+H+ICBk8DqDHhDUjXoWqm/03sy08tGD2X785oAxqpRR6FKQu2Rvxo5UtfbD7l5UFzw==}
@@ -3842,6 +4060,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4935,6 +5156,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -4959,6 +5184,12 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
@@ -4976,6 +5207,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -5383,6 +5616,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5445,6 +5680,8 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -5461,6 +5698,8 @@ snapshots:
       supports-color: 7.2.0
 
   change-case@5.4.4: {}
+
+  character-entities@2.0.2: {}
 
   check-error@2.1.3: {}
 
@@ -5520,6 +5759,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5550,6 +5793,10 @@ snapshots:
   detect-indent@7.0.2: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -5785,6 +6032,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -5998,6 +6247,8 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6253,6 +6504,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-plain-obj@4.1.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6414,6 +6667,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -6432,7 +6687,302 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   min-indent@1.0.1: {}
 
@@ -6738,6 +7288,32 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -7041,6 +7617,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -7128,6 +7706,35 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -7175,6 +7782,21 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  vfile-matter@5.0.1:
+    dependencies:
+      vfile: 6.0.3
+      yaml: 2.9.0
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-ssr-components@0.6.1:
     dependencies:
@@ -7339,3 +7961,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,11 @@
   },
   "vars": {
     "APP_ENV": "development",
+    // Artifacts (コンテンツ正本) の参照設定。REST 呼び出しに使う。
+    // ARTIFACTS_ACCOUNT_ID は secret として与える (`wrangler secret put`)。
+    "ARTIFACTS_NAMESPACE": "yantene",
+    "ARTIFACTS_REPO": "notes",
+    "ARTIFACTS_BRANCH": "main",
   },
   "d1_databases": [
     {
@@ -18,14 +23,22 @@
       "migrations_dir": "./migrations",
     },
   ],
-  // R2 bindings are available but currently unused.
-  // Uncomment when R2 storage is needed.
-  // "r2_buckets": [
-  // 	{
-  // 		"binding": "R2",
-  // 		"bucket_name": "yantene-development"
-  // 	}
-  // ],
+  // R2: パース済み MDAST と画像アセットのキャッシュ (ADR 0005)。
+  "r2_buckets": [
+    {
+      "binding": "R2",
+      "bucket_name": "yantene-development",
+    },
+  ],
+  // Artifacts: コンテンツ正本 (Markdown + 画像)。binding は repo 管理と read トークン
+  // 発行に使い、ファイル内容の読み取りは REST API で行う (ADR 0007)。
+  "artifacts": [
+    {
+      "binding": "ARTIFACTS",
+      "namespace": "yantene",
+      "remote": true,
+    },
+  ],
   "kv_namespaces": [
     {
       "binding": "KV",
@@ -45,6 +58,9 @@
       "workers_dev": true,
       "vars": {
         "APP_ENV": "staging",
+        "ARTIFACTS_NAMESPACE": "yantene",
+        "ARTIFACTS_REPO": "notes",
+        "ARTIFACTS_BRANCH": "main",
       },
       "d1_databases": [
         {
@@ -53,12 +69,19 @@
           "migrations_dir": "./migrations",
         },
       ],
-      // "r2_buckets": [
-      // 	{
-      // 		"binding": "R2",
-      // 		"bucket_name": "yantene-staging"
-      // 	}
-      // ],
+      "r2_buckets": [
+        {
+          "binding": "R2",
+          "bucket_name": "yantene-staging",
+        },
+      ],
+      "artifacts": [
+        {
+          "binding": "ARTIFACTS",
+          "namespace": "yantene",
+          "remote": true,
+        },
+      ],
       "kv_namespaces": [
         {
           "binding": "KV",
@@ -73,6 +96,9 @@
     "production": {
       "vars": {
         "APP_ENV": "production",
+        "ARTIFACTS_NAMESPACE": "yantene",
+        "ARTIFACTS_REPO": "notes",
+        "ARTIFACTS_BRANCH": "main",
       },
       "d1_databases": [
         {
@@ -81,12 +107,19 @@
           "migrations_dir": "./migrations",
         },
       ],
-      // "r2_buckets": [
-      // 	{
-      // 		"binding": "R2",
-      // 		"bucket_name": "yantene-production"
-      // 	}
-      // ],
+      "r2_buckets": [
+        {
+          "binding": "R2",
+          "bucket_name": "yantene-production",
+        },
+      ],
+      "artifacts": [
+        {
+          "binding": "ARTIFACTS",
+          "namespace": "yantene",
+          "remote": true,
+        },
+      ],
       "kv_namespaces": [
         {
           "binding": "KV",


### PR DESCRIPTION
## 概要

Closes #7 / depends on #4 #5 #6 (stacked on PR #17)

Artifacts → D1 + R2 のコンテンツ同期サービスと `POST /api/refresh` (認証必須)。

> ℹ️ #17 → #14 → #13 にスタック。親 PR マージ後に差分は本 PR 分になります。

## やったこと

- **変更検出** — `IContentStore.listTree` のハッシュと D1 の `sourceHash` を突き合わせ、変わったノートだけ再処理
- **パース** — Markdown → フロントマター (vfile-matter) + MDAST (remark) + summary (先頭 160 字、見出し・脚注・コード除外)
- **画像 URL 解決** — 本文の相対画像を `/api/v1/notes/<slug>/assets/...` に解決してから R2 に MDAST をキャッシュ (ADR 0006)
- **アセットキャッシュ** — 画像を R2 に保存 (拡張子から Content-Type 推定)
- **メタデータ** — フロントマターを VO 化して D1 に upsert
- **掃除** — Artifacts から消えたノートを D1 / R2 から削除
- **頑健性** — 不正フロントマター (publishedOn 欠落等) はスキップし結果サマリに記録

## ドメイン/インフラ変更

- Note エンティティに `sourceHash` を追加 (変更検出用)、`INoteContentCache` を定義
- notes テーブルに `source_hash` カラム追加 (migration `0002`)、`R2NoteContentCache` 実装
- `POST /api/refresh` は `requireSession` 配下 (認証必須) — 未認証は 401

## テスト

- パーサ (フロントマター・summary・MDAST)、refresh サービス統合 (index/cache/画像解決/ハッシュskip/再処理/削除/不正skip)、R2 キャッシュ (R2 モック)、content-type / asset-url ヘルパー

## CI について

⚠️ `deploy-preview` は Cloudflare 都合で失敗。他のコード品質チェック・`migration-check` は pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S