### PR TITLE
fix: BASIC 認証の 401 に WWW-Authenticate を引き継ぐ

### DIFF
--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -70,7 +70,14 @@ app.route("/", createPagesRouter());
 
 app.onError((error, _context) => {
   if (error instanceof HTTPException) {
-    return createProblemResponse(error.status, error.message);
+    const response = createProblemResponse(error.status, error.message);
+    // 認証チャレンジ (WWW-Authenticate, RFC 7235) を Problem Details に引き継ぐ。
+    // これが無いと BASIC 認証の 401 でブラウザが認証ダイアログを出さない。
+    const challenge = error.res?.headers.get("WWW-Authenticate");
+    if (challenge !== undefined && challenge !== null) {
+      response.headers.set("WWW-Authenticate", challenge);
+    }
+    return response;
   }
   // ドメインエラー → HTTP マッピング (Composition Root の責務)。
   if (

--- a/app/backend/middleware/basic-auth.test.ts
+++ b/app/backend/middleware/basic-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import app from "~/backend/index";
+
+const basicAuthEnv = {
+  BASIC_AUTH_USER: "u",
+  BASIC_AUTH_PASS: "p",
+} as unknown as Env;
+
+describe("conditionalBasicAuth (full app)", () => {
+  it("challenges with WWW-Authenticate so browsers show the auth dialog", async () => {
+    const res = await app.request("/health", {}, basicAuthEnv);
+    expect(res.status).toBe(401);
+    // RFC 7235: チャレンジヘッダが無いとブラウザは BASIC 認証ダイアログを出さない。
+    expect(res.headers.get("WWW-Authenticate")).toMatch(/^Basic/);
+  });
+
+  it("allows the request with correct credentials", async () => {
+    const res = await app.request(
+      "/health",
+      { headers: { Authorization: `Basic ${btoa("u:p")}` } },
+      basicAuthEnv,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("is disabled when credentials are not configured", async () => {
+    const res = await app.request("/health", {}, {});
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## 背景
`https://yantene-staging.yantene.workers.dev/` でブラウザの BASIC 認証ダイアログが出ず、`application/problem+json` の 401 が返っていた。

## 原因
`app.onError` が `HTTPException` を RFC 9457 Problem Details に変換する際、`hono/basic-auth` が付与した `WWW-Authenticate` チャレンジヘッダ (RFC 7235) を落としていた。

## 修正
- `onError` で `HTTPException` の `WWW-Authenticate` を Problem Details レスポンスに引き継ぐ
- `middleware/basic-auth` のテストを追加（チャレンジヘッダ有無・認証成否・未設定時の無効化）

## 確認
staging へ先行デプロイ済み。`curl -sD - .../` で `www-authenticate: Basic realm="Secure Area"` を確認。

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)