### PR TITLE
feat: ホーム/全ページをログイン不要で閲覧可能にする

### DIFF
--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -1,13 +1,9 @@
 import { inertia } from "@hono/inertia";
 import { Hono } from "hono";
-import { toPublicUser } from "./user-view";
-import { entityId } from "~/backend/domain/shared";
 import { createLogoutRouter } from "~/backend/handlers/auth/logout.handler";
 import { createMagicLinkRouter } from "~/backend/handlers/auth/magic-link.handler";
 import { createNoteDetailPagesRouter } from "~/backend/handlers/notes/detail.handler";
 import { createNotesPagesRouter } from "~/backend/handlers/notes/pages.handler";
-import { D1UserQueryRepository } from "~/backend/infra/d1/repositories";
-import { requireSessionOrRedirect } from "~/backend/middleware/auth";
 import {
   type LocaleVariables,
   localeMiddleware,
@@ -16,7 +12,7 @@ import { rootView } from "~/frontend/root-view";
 
 type PagesBindings = {
   Bindings: Env;
-  Variables: LocaleVariables & { userId: string };
+  Variables: LocaleVariables;
 };
 
 export function createPagesRouter(): Hono<PagesBindings> {
@@ -25,7 +21,10 @@ export function createPagesRouter(): Hono<PagesBindings> {
   router.use("*", localeMiddleware);
   router.use(inertia({ rootView }));
 
-  // 認証不要 (login UI + magic link strategy + logout)
+  // ホーム (公開・認証不要)。発信のハブとしてノート一覧への導線を持つ。
+  router.get("/", (c) => c.render("home", { locale: c.get("locale") }));
+
+  // ログイン UI + magic link + logout。現状ログインは休眠 (将来の有料記事用に温存)。
   router.get("/login", (c) =>
     c.render("login", {
       locale: c.get("locale"),
@@ -35,28 +34,14 @@ export function createPagesRouter(): Hono<PagesBindings> {
   router.get("/login/sent", (c) =>
     c.render("login-sent", { locale: c.get("locale") }),
   );
-
   router.route("/", createMagicLinkRouter());
   router.route("/", createLogoutRouter());
 
-  // ノートの公開ページ (一覧 / 詳細, 認証不要・クローラー対応)。auth ガードより前に
-  // マウントする。
+  // ノートの公開ページ (一覧 / 詳細, 認証不要・クローラー対応)。
   router.route("/", createNotesPagesRouter());
   router.route("/", createNoteDetailPagesRouter());
 
-  // 以降は認証必須
-  router.use("*", requireSessionOrRedirect);
-
-  router.get("/", async (c) => {
-    const query = new D1UserQueryRepository(c.env.D1);
-    const user = await query.findById(entityId<"User">(c.get("userId")));
-    // session が指す User が消えている (stale session) ときは /login へ戻す。
-    if (user === undefined) return c.redirect("/login", 303);
-    return c.render("home", {
-      locale: c.get("locale"),
-      user: toPublicUser(user),
-    });
-  });
-
+  // 認証必須ページは現状なし。将来 (有料記事等) を追加する際は、ここで
+  // requireSessionOrRedirect を挟んでからマウントする。
   return router;
 }

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,17 +1,8 @@
-import { Head, Link, router } from "@inertiajs/react";
+import { Head, Link } from "@inertiajs/react";
 import { useTranslation } from "react-i18next";
-import type { PageProps } from "~/frontend/page-props";
 import { AppLayout } from "~/frontend/layouts/app-layout";
 
-interface HomeProps extends PageProps {
-  readonly user: {
-    readonly id: string;
-    readonly email: string;
-    readonly displayName: string;
-  };
-}
-
-export default function Home({ user }: HomeProps): React.JSX.Element {
+export default function Home(): React.JSX.Element {
   const { t } = useTranslation();
 
   return (
@@ -19,23 +10,12 @@ export default function Home({ user }: HomeProps): React.JSX.Element {
       <Head title={t("home.heading")} />
       <main className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <h1 className="text-4xl font-bold">
-            {t("home.welcome", { name: user.displayName })}
-          </h1>
-          <p className="mt-4 text-base-content/60">{user.email}</p>
+          <h1 className="text-4xl font-bold">{t("home.heading")}</h1>
+          <p className="mt-4 text-base-content/60">{t("home.tagline")}</p>
           <div className="mt-8 flex items-center justify-center gap-4">
             <Link href="/notes" className="btn btn-primary">
               {t("home.viewNotes")}
             </Link>
-            <button
-              type="button"
-              className="btn btn-ghost"
-              onClick={() => {
-                router.post("/auth/logout");
-              }}
-            >
-              {t("home.logout")}
-            </button>
           </div>
         </div>
       </main>

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -5,6 +5,7 @@
   },
   "home": {
     "heading": "yantene",
+    "tagline": "A hub for everything yantene publishes",
     "welcome": "Welcome, {{name}}",
     "viewNotes": "View notes",
     "logout": "Log out"

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -5,6 +5,7 @@
   },
   "home": {
     "heading": "yantene",
+    "tagline": "yantene の発信を集約するハブ",
     "welcome": "ようこそ、{{name}} さん",
     "viewNotes": "ノートを見る",
     "logout": "ログアウト"


### PR DESCRIPTION
## 背景
現時点でログイン機能は不要。`/`(ホーム) が認証必須で `/login` にリダイレクトされていたため、全ページをログインなしで閲覧可能にする。ログイン基盤は将来の有料記事用に休眠で温存。

## 変更
- `/` を公開ホーム(発信ハブ = ノート一覧への導線)に変更
- `requireSessionOrRedirect` の認証ガードを撤去(認証必須ページは現状なし)
- `home` ページから user 依存を除去し、`home.tagline` を追加
- login/magic-link/logout ルートは休眠のまま温存

## 確認
staging へ先行デプロイ済み。`/` が 303(→/login) から **200** になったことを確認。

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)