### PR TITLE
feat: refresh を X-Refresh-Token シークレットで保護し公開エンドポイント化

### DIFF
--- a/app/backend/handlers/notes/refresh.handler.test.ts
+++ b/app/backend/handlers/notes/refresh.handler.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createRefreshRouter } from "./refresh.handler";
+
+function post(
+  headers: Record<string, string>,
+  env: Env,
+): Response | Promise<Response> {
+  return createRefreshRouter().request(
+    "/refresh",
+    { method: "POST", headers },
+    env,
+  );
+}
+
+describe("createRefreshRouter POST /refresh", () => {
+  it("fails loud (500) when REFRESH_SECRET is not configured", async () => {
+    const res = await post(
+      { "X-Refresh-Token": "anything" },
+      {} as unknown as Env,
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("rejects (401) when the token header is missing", async () => {
+    const res = await post({}, { REFRESH_SECRET: "s3cr3t" } as unknown as Env);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects (401) when the token does not match", async () => {
+    const res = await post({ "X-Refresh-Token": "wrong" }, {
+      REFRESH_SECRET: "s3cr3t",
+    } as unknown as Env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/backend/handlers/notes/refresh.handler.ts
+++ b/app/backend/handlers/notes/refresh.handler.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { resolveContentStore } from "./resolve-content-store";
 import {
   D1NoteCommandRepository,
@@ -7,16 +8,44 @@ import {
 import { R2NoteContentCache } from "~/backend/infra/r2/r2-note-content-cache";
 import { NotesRefreshService } from "~/backend/services/notes-refresh.service";
 
+/** シークレットを載せるヘッダ。staging の BASIC 認証 (Authorization) と衝突しないよう専用ヘッダにする。 */
+const REFRESH_TOKEN_HEADER = "X-Refresh-Token";
+
+/** 定数時間で文字列を比較する (タイミング攻撃対策)。 */
+function isEqualConstantTime(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= (a.codePointAt(i) ?? 0) ^ (b.codePointAt(i) ?? 0);
+  }
+  return diff === 0;
+}
+
 /**
- * ノート同期 (refresh) の JSON API ルータ。認証必須 (index.ts で requireSession 配下に
- * マウントする)。Composition Root として具象を生成し NotesRefreshService に注入する。
+ * ノート同期 (refresh) の JSON API ルータ。
  *
- * POST /refresh → Artifacts を D1 + R2 に同期し、処理結果サマリを返す。
+ * 認証はユーザ session ではなく運用シークレット (`REFRESH_SECRET`) で行う。コンテンツ
+ * 同期は CI/運用操作であり、`yantene/notes` への push を契機に叩かれるため。
+ *
+ * - `REFRESH_SECRET` 未設定なら静かに無効化せず fail-loud で throw する (secure by default)。
+ * - `X-Refresh-Token` ヘッダが一致しなければ 401。
+ * - `POST /refresh` → コンテンツ正本を D1 + R2 に同期し、処理結果サマリを返す。
  */
 export function createRefreshRouter(): Hono<{ Bindings: Env }> {
   const router = new Hono<{ Bindings: Env }>();
 
   router.post("/refresh", async (c) => {
+    const secret = (c.env as unknown as { REFRESH_SECRET?: unknown })
+      .REFRESH_SECRET;
+    if (typeof secret !== "string" || secret.length === 0) {
+      throw new Error("REFRESH_SECRET is required to trigger a refresh.");
+    }
+
+    const provided = c.req.header(REFRESH_TOKEN_HEADER);
+    if (provided === undefined || !isEqualConstantTime(provided, secret)) {
+      throw new HTTPException(401, { message: "Invalid refresh token." });
+    }
+
     const service = new NotesRefreshService(
       resolveContentStore(c.env),
       new D1NoteCommandRepository(c.env.D1),

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -59,11 +59,14 @@ app.route("/api/v1/notes", createNotesApiRouter());
 app.route("/api/v1/notes", createNoteDetailApiRouter());
 app.route("/api/v1/notes", createNoteAssetsRouter());
 
+// ノート同期 (コンテンツ正本 → D1 + R2)。POST /api/v1/refresh。
+// session ではなく REFRESH_SECRET で保護する運用エンドポイントなので、requireSession
+// より前にマウントして認証ガードを通さない。
+app.route("/api/v1", createRefreshRouter());
+
 // 認証必須 JSON API
 app.use("/api/*", requireSession);
 app.route("/api", createApiRouter());
-// ノート同期 (Artifacts → D1 + R2)。認証必須。
-app.route("/api", createRefreshRouter());
 
 // Inertia.js ページルート (locale + inertia ミドルウェアは router 内で適用)
 app.route("/", createPagesRouter());


### PR DESCRIPTION
## 背景
ログイン無効化により session 必須の refresh が叩けない。コンテンツ同期は運用/CI 操作なのでシークレットで保護する。Closes #25

## 変更
- `POST /api/v1/refresh` を `requireSession` の外へマウント
- `X-Refresh-Token` ヘッダの `REFRESH_SECRET` で保護 (未設定→fail-loud / 不一致→401 / 定数時間比較)
- ※ staging の BASIC 認証が Authorization を使うため Bearer ではなく専用ヘッダ
- テスト追加 (未設定 500 / ヘッダ無し 401 / 不一致 401)

## 別途 (この PR 外)
`yantene/notes` に push→refresh の GitHub Actions を追加。worker に `REFRESH_SECRET`、repo に関連 secret を設定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)