### PR TITLE
fix: ContentStore の default fetch を正しい this で呼ぶ

### DIFF
--- a/app/backend/infra/artifacts/artifacts-content-store.ts
+++ b/app/backend/infra/artifacts/artifacts-content-store.ts
@@ -53,7 +53,14 @@ export class ArtifactsContentStore implements IContentStore {
   constructor(private readonly config: ArtifactsContentStoreConfig) {
     this.branch = config.branch ?? "main";
     this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
-    this.fetchFn = config.fetchFn ?? fetch;
+    // global fetch は正しい this (globalThis) で呼ぶ必要がある。プロパティ経由の
+    // メソッド呼び出しだと this が instance になり Workers が Illegal invocation を投げる。
+    this.fetchFn =
+      config.fetchFn ??
+      ((
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ) => fetch(input, init));
   }
 
   private repoPath(): string {

--- a/app/backend/infra/github/github-content-store.ts
+++ b/app/backend/infra/github/github-content-store.ts
@@ -47,7 +47,14 @@ export class GitHubContentStore implements IContentStore {
   constructor(private readonly config: GitHubContentStoreConfig) {
     this.branch = config.branch ?? "main";
     this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
-    this.fetchFn = config.fetchFn ?? fetch;
+    // global fetch は正しい this (globalThis) で呼ぶ必要がある。プロパティ経由の
+    // メソッド呼び出しだと this が instance になり Workers が Illegal invocation を投げる。
+    this.fetchFn =
+      config.fetchFn ??
+      ((
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ) => fetch(input, init));
   }
 
   private repoPath(): string {


### PR DESCRIPTION
## 事象
`POST /api/v1/refresh` が 500。Worker ログに `TypeError: Illegal invocation: function called with incorrect this reference`。実データ (yantene/notes 27 記事) の同期が全く動かなかった。

## 原因
`GitHubContentStore` / `ArtifactsContentStore` が `this.fetchFn = config.fetchFn ?? fetch` で global `fetch` をプロパティ保持し、`this.fetchFn(url, ...)` とメソッド呼び出しするため、`fetch` に instance が `this` として渡り Cloudflare Workers が Illegal invocation を投げていた。

## 修正
default fetch を global fetch を呼ぶラッパにする。両 ContentStore を修正。

## 確認
staging へ先行デプロイし refresh を実行 → **27 記事 + 画像がすべて同期・表示**を確認 (一覧/詳細/画像アセットすべて 200)。

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)