### PR TITLE
feat: 読書体験を改善 (ライト固定 + note 風タイポグラフィ + placeholder)

### DIFF
--- a/app/frontend/app.css
+++ b/app/frontend/app.css
@@ -2,14 +2,20 @@
 @plugin "daisyui";
 @plugin "@tailwindcss/typography";
 
+/* ダークモードは採用しない (読書体験としてダークは不採用・light 固定)。 */
 @plugin "daisyui/theme" {
   name: "light";
   default: true;
   color-scheme: light;
 }
 
-@plugin "daisyui/theme" {
-  name: "dark";
-  prefersdark: true;
-  color-scheme: dark;
+/* サイト全体のフォント。外部読込なしでシステムの日本語フォントを優先する。 */
+@layer base {
+  html {
+    font-family:
+      "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", "Yu Gothic",
+      YuGothic, Meiryo, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
 }

--- a/app/frontend/components/mdast/mdast-renderer.css
+++ b/app/frontend/components/mdast/mdast-renderer.css
@@ -4,7 +4,17 @@
  * これらを参照しておけばテーマ追従が自動で効く (tailwind の dark: バリアント不要)。
  */
 .note-prose {
-  --tw-prose-body: var(--color-base-content);
+  /* note 参考の可読タイポグラフィ: やや大きめ・行間広め・字間ゆとり。 */
+  font-size: 1.0625rem;
+  line-height: 2;
+  letter-spacing: 0.02em;
+  word-break: break-word;
+  /* 本文は真っ黒を避け、柔らかいダークグレーに (長文でも目が疲れにくい)。 */
+  --tw-prose-body: color-mix(
+    in oklch,
+    var(--color-base-content) 85%,
+    transparent
+  );
   --tw-prose-headings: var(--color-base-content);
   --tw-prose-lead: color-mix(
     in oklch,
@@ -40,6 +50,30 @@
   --tw-prose-pre-bg: var(--color-base-200);
   --tw-prose-th-borders: var(--color-base-300);
   --tw-prose-td-borders: var(--color-base-300);
+}
+
+/* note 風の段落・見出しリズム (日本語の可読性重視)。 */
+.note-prose :where(p) {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+.note-prose :where(h2) {
+  margin-top: 2.75em;
+  margin-bottom: 1em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--color-base-300);
+  font-weight: 700;
+}
+.note-prose :where(h3) {
+  margin-top: 2em;
+  font-weight: 700;
+}
+.note-prose :where(img) {
+  margin-inline: auto;
+  border-radius: 0.5rem;
+}
+.note-prose :where(a) {
+  text-underline-offset: 0.2em;
 }
 
 /* インラインコードの背景 (prose 既定は透明なので軽く敷く)。 */

--- a/app/frontend/pages/notes/index.tsx
+++ b/app/frontend/pages/notes/index.tsx
@@ -74,8 +74,14 @@ export default function NotesIndex({
                   href={`/notes/${note.slug}`}
                   className="card card-side bg-base-200 shadow-sm transition-shadow hover:shadow-md"
                 >
-                  {note.imageUrl !== null && (
-                    <figure className="w-32 shrink-0">
+                  <figure className="w-32 shrink-0">
+                    {note.imageUrl === null ? (
+                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/15 to-secondary/15">
+                        <span className="text-3xl font-bold text-primary/40">
+                          {note.title.charAt(0) || "?"}
+                        </span>
+                      </div>
+                    ) : (
                       <img
                         src={note.imageUrl}
                         alt=""
@@ -83,8 +89,8 @@ export default function NotesIndex({
                         decoding="async"
                         className="h-full w-full object-cover"
                       />
-                    </figure>
-                  )}
+                    )}
+                  </figure>
                   <div className="card-body">
                     <h2 className="card-title">{note.title}</h2>
                     <time

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -10,8 +10,6 @@ import { renderPage } from "~/frontend/entry.server";
 import { isSupportedLocale, type SupportedLocale } from "~/lib/i18n/locale";
 import resources from "~/lib/i18n/locales";
 
-const themeInitScript = `(function(){try{var t=localStorage.getItem("theme");if(t!=="light"&&t!=="dark")t=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";document.documentElement.setAttribute("data-theme",t)}catch(e){document.documentElement.setAttribute("data-theme","light")}})();`;
-
 interface HeadProps {
   readonly title: string;
   readonly description: string;
@@ -41,7 +39,7 @@ function resolveLocale(page: {
   return typeof value === "string" && isSupportedLocale(value) ? value : "en";
 }
 
-export const rootView: RootView = async (page, c) => {
+export const rootView: RootView = async (page) => {
   const locale = resolveLocale(page);
   // eslint-disable-next-line security/detect-object-injection -- locale is narrowed to SupportedLocale literal
   const translations = resources[locale].translation;
@@ -52,20 +50,13 @@ export const rootView: RootView = async (page, c) => {
     renderToString(<Head title={meta.title} description={meta.description} />) +
     head.join("");
 
-  const nonceValue = c.get("secureHeadersNonce");
-  const nonce = typeof nonceValue === "string" ? nonceValue : "";
-  const themeScript =
-    nonce.length > 0
-      ? `<script nonce="${nonce}">${themeInitScript}</script>`
-      : `<script>${themeInitScript}</script>`;
-
   // body には Inertia の SSR 出力 (<script data-page="app"> + <div id="app">) が
   // すでに含まれている。ここで <div id="app"> を重ねて巻くと id が重複し、
   // hydration 対象がずれる・data-page 属性が壊れるため、body をそのまま配置する。
+  // テーマは light 固定 (ダークモード不採用)。
   return `<!DOCTYPE html>
-<html lang="${locale}" suppressHydrationWarning>
+<html lang="${locale}" data-theme="light">
   <head>
-    ${themeScript}
     ${headHtml}
   </head>
   <body>


### PR DESCRIPTION
## 目的
記事の読書体験を洗練させる。Closes #29

## 変更
- **ダークモード撤去** — light 固定。テーマ切替/prefers-dark スクリプトを廃止し `<html data-theme="light">` 固定
- **note 風タイポグラフィ** — 行間 2.0・font-size 1.0625rem・字間 0.02em・本文色を柔らかいダークグレー・段落/見出しのリズム調整・システム日本語フォント優先(外部読込なし)
- **アイキャッチ placeholder** — 画像未設定の記事は一覧でタイトル頭文字+グラデを表示

## 確認
staging へ先行デプロイ済み。`/notes`・詳細ページで確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)