### PR TITLE
feat: タグ機能を実装する

### DIFF
--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -1,6 +1,7 @@
 export { NoteNotFoundError } from "./errors";
 export { ImageUrl, InvalidImageUrlError } from "./image-url.vo";
 export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
+export { InvalidNoteTagError, NoteTag } from "./note-tag.vo";
 export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
 export { Note } from "./note.entity";
 export type { NoteId } from "./note.entity";
@@ -14,5 +15,6 @@ export type {
   NoteListQuery,
   NoteListResult,
   NoteSortField,
+  NoteTagCount,
   SortDirection,
 } from "./note.query-repository.interface";

--- a/app/backend/domain/note/note-tag.vo.ts
+++ b/app/backend/domain/note/note-tag.vo.ts
@@ -1,0 +1,36 @@
+import type { IValueObject } from "~/backend/domain/shared";
+
+// タグはフロントマター由来のラベル (例: "日記", "GNU/Linux", "競技プログラミング")。
+// 大文字小文字・記号 (スラッシュ等) はそのまま保つが、前後空白を正規化し、
+// 空文字と過長を弾く。
+const MAX_LENGTH = 50;
+
+export class InvalidNoteTagError extends Error {
+  readonly name = "InvalidNoteTagError";
+}
+
+export class NoteTag implements IValueObject<NoteTag> {
+  private constructor(private readonly value: string) {}
+
+  static create(raw: string): NoteTag {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+      throw new InvalidNoteTagError(
+        `Note tag must be 1..${String(MAX_LENGTH)} characters long`,
+      );
+    }
+    return new NoteTag(trimmed);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: NoteTag): boolean {
+    return this.value === other.value;
+  }
+
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -61,6 +61,7 @@ describe("Note.reconstruct", () => {
       title,
       summary: "s",
       imageUrl: undefined,
+      tags: [],
       publishedOn,
       lastModifiedOn,
       sourceHash: "h",

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -1,5 +1,6 @@
 import type { ImageUrl } from "./image-url.vo";
 import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTag } from "./note-tag.vo";
 import type { NoteTitle } from "./note-title.vo";
 import type { Temporal } from "@js-temporal/polyfill";
 import type {
@@ -18,6 +19,8 @@ interface NoteFields<T extends IPersisted | IUnpersisted> {
   readonly summary: string;
   /** カバー画像 URL。フロントマターに imageUrl が無ければ undefined。 */
   readonly imageUrl: ImageUrl | undefined;
+  /** フロントマター由来のタグ。順序は定義順を保つ。無ければ空配列。 */
+  readonly tags: readonly NoteTag[];
   /** フロントマター由来の公開日 (日付のみ)。 */
   readonly publishedOn: Temporal.PlainDate;
   /** フロントマター由来の最終更新日 (日付のみ)。 */
@@ -45,6 +48,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     title: NoteTitle;
     summary: string;
     imageUrl?: ImageUrl;
+    tags?: readonly NoteTag[];
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
     sourceHash: string;
@@ -55,6 +59,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
       title: params.title,
       summary: params.summary,
       imageUrl: params.imageUrl,
+      tags: params.tags ?? [],
       publishedOn: params.publishedOn,
       lastModifiedOn: params.lastModifiedOn,
       sourceHash: params.sourceHash,
@@ -69,6 +74,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     title: NoteTitle;
     summary: string;
     imageUrl: ImageUrl | undefined;
+    tags: readonly NoteTag[];
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
     sourceHash: string;
@@ -96,6 +102,10 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
 
   get imageUrl(): ImageUrl | undefined {
     return this.fields.imageUrl;
+  }
+
+  get tags(): readonly NoteTag[] {
+    return this.fields.tags;
   }
 
   get publishedOn(): Temporal.PlainDate {

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -15,17 +15,27 @@ export interface NoteListQuery {
   readonly offset: number;
   readonly sortBy: NoteSortField;
   readonly direction: SortDirection;
+  /** 指定時、そのタグを持つノートだけに絞り込む。 */
+  readonly tag?: string;
 }
 
-/** 一覧の取得結果。total は絞り込み前の全件数 (ページネーション用)。 */
+/** 一覧の取得結果。total は (絞り込み後の) 全件数 (ページネーション用)。 */
 export interface NoteListResult {
   readonly notes: readonly Note[];
   readonly total: number;
 }
 
+/** タグと、そのタグを持つノート数。 */
+export interface NoteTagCount {
+  readonly tag: string;
+  readonly count: number;
+}
+
 export interface INoteQueryRepository {
   findBySlug(slug: NoteSlug): Promise<Note | undefined>;
   list(query: NoteListQuery): Promise<NoteListResult>;
+  /** 全タグと各記事数を返す (タグ索引ページ用)。件数降順・タグ昇順。 */
+  listTags(): Promise<readonly NoteTagCount[]>;
   /**
    * 全ノートの slug → sourceHash の対応を返す。refresh の変更検出に使う
    * (Artifacts のツリーが返すハッシュと突き合わせる)。

--- a/app/backend/handlers/note-view.ts
+++ b/app/backend/handlers/note-view.ts
@@ -15,6 +15,7 @@ export interface PublicNote {
   readonly title: string;
   readonly summary: string;
   readonly imageUrl: string | null;
+  readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
 }
@@ -38,9 +39,16 @@ export function toPublicNote(note: Note): PublicNote {
     title: note.title.toJSON(),
     summary: note.summary,
     imageUrl: note.imageUrl?.toJSON() ?? null,
+    tags: note.tags.map((tag) => tag.toJSON()),
     publishedOn: note.publishedOn.toString({ calendarName: "never" }),
     lastModifiedOn: note.lastModifiedOn.toString({ calendarName: "never" }),
   };
+}
+
+/** クエリ文字列 (tag) を検証済みの絞り込みタグに解決する。空・空白は未指定扱い。 */
+export function parseTag(tagParam: string | undefined): string | undefined {
+  const trimmed = tagParam?.trim();
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
 }
 
 /** ページネーション付きの一覧結果を公開 DTO へ変換する。 */

--- a/app/backend/handlers/notes/list-api.handler.test.ts
+++ b/app/backend/handlers/notes/list-api.handler.test.ts
@@ -105,6 +105,7 @@ describe("createNotesApiRouter GET /", () => {
       "publishedOn",
       "slug",
       "summary",
+      "tags",
       "title",
     ]);
     expect(first.imageUrl).toBeNull();

--- a/app/backend/handlers/notes/list-api.handler.ts
+++ b/app/backend/handlers/notes/list-api.handler.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import {
   parseNoteSort,
   parsePagination,
+  parseTag,
   toPublicNoteList,
 } from "~/backend/handlers/note-view";
 import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
@@ -26,8 +27,10 @@ export function createNotesApiRouter(): Hono<{ Bindings: Env }> {
       c.req.query("order"),
     );
 
+    const tag = parseTag(c.req.query("tag"));
+
     const query = new D1NoteQueryRepository(c.env.D1);
-    const result = await query.list({ limit, offset, sortBy, direction });
+    const result = await query.list({ limit, offset, sortBy, direction, tag });
     return c.json(toPublicNoteList(result, page, perPage));
   });
 

--- a/app/backend/handlers/notes/note-detail-view.ts
+++ b/app/backend/handlers/notes/note-detail-view.ts
@@ -6,6 +6,7 @@ export interface PublicNoteMeta {
   readonly title: string;
   readonly summary: string;
   readonly imageUrl: string | null;
+  readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
 }
@@ -23,6 +24,7 @@ export function toNoteDetail(note: Note, mdast: unknown): NoteDetail {
       title: note.title.toJSON(),
       summary: note.summary,
       imageUrl: note.imageUrl?.toJSON() ?? null,
+      tags: note.tags.map((tag) => tag.toJSON()),
       publishedOn: note.publishedOn.toString({ calendarName: "never" }),
       lastModifiedOn: note.lastModifiedOn.toString({ calendarName: "never" }),
     },

--- a/app/backend/handlers/notes/pages.handler.ts
+++ b/app/backend/handlers/notes/pages.handler.ts
@@ -3,6 +3,7 @@ import type { LocaleVariables } from "~/backend/middleware/locale";
 import {
   parseNoteSort,
   parsePagination,
+  parseTag,
   toPublicNoteList,
 } from "~/backend/handlers/note-view";
 import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
@@ -30,13 +31,16 @@ export function createNotesPagesRouter(): Hono<NotesPagesBindings> {
       c.req.query("order"),
     );
 
+    const tag = parseTag(c.req.query("tag"));
+
     const query = new D1NoteQueryRepository(c.env.D1);
-    const result = await query.list({ limit, offset, sortBy, direction });
+    const result = await query.list({ limit, offset, sortBy, direction, tag });
 
     return c.render("notes/index", {
       locale: c.get("locale"),
       ...toPublicNoteList(result, page, perPage),
-      // ページ送りリンクで現在の並び順を保持するため、生のクエリ値を渡す。
+      // ページ送りリンク・見出しで使うため、現在の絞り込みタグと並び順を渡す。
+      tag: tag ?? null,
       sort: {
         sortBy: c.req.query("sort-by") ?? null,
         order: c.req.query("order") ?? null,

--- a/app/backend/handlers/notes/tags.handler.ts
+++ b/app/backend/handlers/notes/tags.handler.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import type { LocaleVariables } from "~/backend/middleware/locale";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+type TagsPagesBindings = {
+  Bindings: Env;
+  Variables: LocaleVariables;
+};
+
+/**
+ * タグ索引の公開ページルータ (Inertia)。認証不要。
+ * GET /tags → 全タグと各記事数の一覧。
+ */
+export function createTagsPagesRouter(): Hono<TagsPagesBindings> {
+  const router = new Hono<TagsPagesBindings>();
+
+  router.get("/tags", async (c) => {
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const tags = await query.listTags();
+    return c.render("tags/index", { locale: c.get("locale"), tags });
+  });
+
+  return router;
+}
+
+/**
+ * タグ索引の公開 JSON API ルータ。認証不要 (クローラー対応)。
+ * index.ts で auth ガードより前に `/api/v1/tags` にマウントする。
+ * GET / → 全タグと各記事数。
+ */
+export function createTagsApiRouter(): Hono<{ Bindings: Env }> {
+  const router = new Hono<{ Bindings: Env }>();
+
+  router.get("/", async (c) => {
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const tags = await query.listTags();
+    return c.json({ tags });
+  });
+
+  return router;
+}

--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -4,6 +4,7 @@ import { createLogoutRouter } from "~/backend/handlers/auth/logout.handler";
 import { createMagicLinkRouter } from "~/backend/handlers/auth/magic-link.handler";
 import { createNoteDetailPagesRouter } from "~/backend/handlers/notes/detail.handler";
 import { createNotesPagesRouter } from "~/backend/handlers/notes/pages.handler";
+import { createTagsPagesRouter } from "~/backend/handlers/notes/tags.handler";
 import {
   type LocaleVariables,
   localeMiddleware,
@@ -37,9 +38,10 @@ export function createPagesRouter(): Hono<PagesBindings> {
   router.route("/", createMagicLinkRouter());
   router.route("/", createLogoutRouter());
 
-  // ノートの公開ページ (一覧 / 詳細, 認証不要・クローラー対応)。
+  // ノートの公開ページ (一覧 / 詳細 / タグ索引, 認証不要・クローラー対応)。
   router.route("/", createNotesPagesRouter());
   router.route("/", createNoteDetailPagesRouter());
+  router.route("/", createTagsPagesRouter());
 
   // 認証必須ページは現状なし。将来 (有料記事等) を追加する際は、ここで
   // requireSessionOrRedirect を挟んでからマウントする。

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -10,6 +10,7 @@ import { createNoteAssetsRouter } from "./handlers/notes/assets.handler";
 import { createNoteDetailApiRouter } from "./handlers/notes/detail.handler";
 import { createNotesApiRouter } from "./handlers/notes/list-api.handler";
 import { createRefreshRouter } from "./handlers/notes/refresh.handler";
+import { createTagsApiRouter } from "./handlers/notes/tags.handler";
 import { createPagesRouter } from "./handlers/pages";
 import { NoteNotFoundError } from "~/backend/domain/note";
 import { UserNotFoundError } from "~/backend/domain/user";
@@ -58,6 +59,7 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 app.route("/api/v1/notes", createNotesApiRouter());
 app.route("/api/v1/notes", createNoteDetailApiRouter());
 app.route("/api/v1/notes", createNoteAssetsRouter());
+app.route("/api/v1/tags", createTagsApiRouter());
 
 // ノート同期 (コンテンツ正本 → D1 + R2)。POST /api/v1/refresh。
 // session ではなく REFRESH_SECRET で保護する運用エンドポイントなので、requireSession

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -1,3 +1,4 @@
+import type { NoteTag } from "~/backend/domain/note";
 import type { notes } from "~/backend/infra/d1/schema";
 import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
 import { entityId } from "~/backend/domain/shared";
@@ -7,14 +8,20 @@ import { isoToPlainDate, unixToInstant } from "~/backend/infra/d1/temporal";
  * D1 の行を Note エンティティに復元する。Command / Query リポジトリで共有する。
  * slug / title / imageUrl は保存時に VO 経由で検証済みなので、ここでの再検証は
  * 破損データの検知を兼ねる (不正なら VO factory が throw する)。
+ *
+ * タグは別テーブル (note_tags) にあるため、呼び出し側が読み込んで渡す。
  */
-export function rowToNote(row: typeof notes.$inferSelect): Note {
+export function rowToNote(
+  row: typeof notes.$inferSelect,
+  tags: readonly NoteTag[] = [],
+): Note {
   return Note.reconstruct({
     id: entityId<"Note">(row.id),
     slug: NoteSlug.create(row.slug),
     title: NoteTitle.create(row.title),
     summary: row.summary,
     imageUrl: row.imageUrl === null ? undefined : ImageUrl.create(row.imageUrl),
+    tags,
     publishedOn: isoToPlainDate(row.publishedOn),
     lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
     sourceHash: row.sourceHash,

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@js-temporal/polyfill";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { rowToNote } from "./note-row";
 import type {
@@ -9,7 +9,7 @@ import type {
   NoteSlug,
 } from "~/backend/domain/note";
 import type { IUnpersisted } from "~/backend/domain/shared";
-import { notes } from "~/backend/infra/d1/schema";
+import { noteTags, notes } from "~/backend/infra/d1/schema";
 import { instantToUnix, plainDateToIso } from "~/backend/infra/d1/temporal";
 
 export class D1NoteCommandRepository implements INoteCommandRepository {
@@ -22,7 +22,7 @@ export class D1NoteCommandRepository implements INoteCommandRepository {
   /**
    * slug をキーに upsert する。新規なら id と created_at を採番し、既存なら
    * それらを保持したまま内容と updated_at を更新する。RETURNING で確定行を取り、
-   * 永続化済みエンティティを復元して返す。
+   * タグ (note_tags) を入れ直してから永続化済みエンティティを復元して返す。
    */
   async upsert(note: Note<IUnpersisted>): Promise<Note> {
     const now = Temporal.Now.instant();
@@ -48,14 +48,34 @@ export class D1NoteCommandRepository implements INoteCommandRepository {
       .onConflictDoUpdate({ target: notes.slug, set: content })
       .returning();
 
-    return rowToNote(row);
+    await this.replaceTags(row.id, note.tags);
+
+    return rowToNote(row, note.tags);
+  }
+
+  /** ノートのタグを丸ごと入れ替える (差分計算より単純で確実)。重複タグは除去する。 */
+  private async replaceTags(noteId: string, tags: Note["tags"]): Promise<void> {
+    await this.db.delete(noteTags).where(eq(noteTags.noteId, noteId));
+    const unique = [...new Set(tags.map((tag) => tag.toString()))];
+    if (unique.length > 0) {
+      await this.db
+        .insert(noteTags)
+        .values(unique.map((tag) => ({ noteId, tag })));
+    }
   }
 
   async deleteBySlug(slug: NoteSlug): Promise<void> {
+    // note_tags は FK cascade だが D1 は FK 強制が既定で無効なため明示的に掃除する。
+    const noteIds = this.db
+      .select({ id: notes.id })
+      .from(notes)
+      .where(eq(notes.slug, slug.toString()));
+    await this.db.delete(noteTags).where(inArray(noteTags.noteId, noteIds));
     await this.db.delete(notes).where(eq(notes.slug, slug.toString()));
   }
 
   async delete(id: NoteId): Promise<void> {
+    await this.db.delete(noteTags).where(eq(noteTags.noteId, id));
     await this.db.delete(notes).where(eq(notes.id, id));
   }
 }

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -3,8 +3,24 @@ import { describe, expect, it } from "vitest";
 import { D1NoteCommandRepository } from "./note.command-repository";
 import { D1NoteQueryRepository } from "./note.query-repository";
 import type { IUnpersisted } from "~/backend/domain/shared";
-import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import { Note, NoteSlug, NoteTag, NoteTitle } from "~/backend/domain/note";
 import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function seedTagged(
+  slug: string,
+  publishedOn: string,
+  tags: readonly string[],
+): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(slug),
+    title: NoteTitle.create(slug),
+    summary: "s",
+    tags: tags.map((tag) => NoteTag.create(tag)),
+    publishedOn: Temporal.PlainDate.from(publishedOn),
+    lastModifiedOn: Temporal.PlainDate.from(publishedOn),
+    sourceHash: `hash-${slug}`,
+  });
+}
 
 function seed(params: {
   slug: string;
@@ -125,5 +141,64 @@ describe("D1NoteQueryRepository", () => {
     // slug 昇順で安定 → ページをまたいで a, b, c が重複なく並ぶ。
     expect(page1.notes.map((n) => n.slug.toString())).toEqual(["a", "b"]);
     expect(page2.notes.map((n) => n.slug.toString())).toEqual(["c"]);
+  });
+
+  it("loads a note's tags on findBySlug", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      seedTagged("t", "2026-01-01", ["日記", "プログラミング"]),
+    );
+    const found = await new D1NoteQueryRepository(d1).findBySlug(
+      NoteSlug.create("t"),
+    );
+    expect(
+      found?.tags
+        .map((tag) => tag.toString())
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(["プログラミング", "日記"]);
+  });
+
+  it("filters the list by tag (total = filtered count)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    await cmd.upsert(seedTagged("a", "2026-01-01", ["日記"]));
+    await cmd.upsert(seedTagged("b", "2026-02-01", ["日記", "試験"]));
+    await cmd.upsert(seedTagged("c", "2026-03-01", ["試験"]));
+
+    const { notes, total } = await new D1NoteQueryRepository(d1).list({
+      limit: 10,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+      tag: "日記",
+    });
+
+    expect(total).toBe(2);
+    expect(notes.map((n) => n.slug.toString())).toEqual(["b", "a"]);
+  });
+
+  it("lists tags with counts (count desc)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    await cmd.upsert(seedTagged("a", "2026-01-01", ["日記"]));
+    await cmd.upsert(seedTagged("b", "2026-02-01", ["日記", "試験"]));
+
+    const tags = await new D1NoteQueryRepository(d1).listTags();
+    expect(tags).toEqual([
+      { tag: "日記", count: 2 },
+      { tag: "試験", count: 1 },
+    ]);
+  });
+
+  it("replaces tags on re-upsert (no stale tags)", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    await cmd.upsert(seedTagged("x", "2026-01-01", ["古い"]));
+    await cmd.upsert(seedTagged("x", "2026-01-01", ["新しい"]));
+
+    const found = await new D1NoteQueryRepository(d1).findBySlug(
+      NoteSlug.create("x"),
+    );
+    expect(found?.tags.map((tag) => tag.toString())).toEqual(["新しい"]);
   });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -1,4 +1,4 @@
-import { asc, count, desc, eq } from "drizzle-orm";
+import { asc, count, desc, eq, inArray, type SQL } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { rowToNote } from "./note-row";
 import type {
@@ -8,8 +8,10 @@ import type {
   NoteListResult,
   NoteSlug,
   NoteSortField,
+  NoteTagCount,
 } from "~/backend/domain/note";
-import { notes } from "~/backend/infra/d1/schema";
+import { NoteTag } from "~/backend/domain/note";
+import { noteTags, notes } from "~/backend/infra/d1/schema";
 
 const sortColumns = {
   publishedOn: notes.publishedOn,
@@ -30,10 +32,24 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
       .where(eq(notes.slug, slug.toString()))
       .limit(1);
     const row = rows.at(0);
-    return row === undefined ? undefined : rowToNote(row);
+    if (row === undefined) return undefined;
+    const tags = await this.loadTags([row.id]);
+    return rowToNote(row, tags.get(row.id) ?? []);
   }
 
   async list(query: NoteListQuery): Promise<NoteListResult> {
+    // タグ絞り込み: そのタグを持つノート id に限定する。
+    const filter: SQL | undefined =
+      query.tag === undefined
+        ? undefined
+        : inArray(
+            notes.id,
+            this.db
+              .select({ id: noteTags.noteId })
+              .from(noteTags)
+              .where(eq(noteTags.tag, query.tag)),
+          );
+
     const column = sortColumns[query.sortBy];
     const primary = query.direction === "asc" ? asc(column) : desc(column);
     // 同じ日付のノート同士でも順序を安定させる決定的なタイブレーカ。slug は UNIQUE
@@ -45,13 +61,27 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
       this.db
         .select()
         .from(notes)
+        .where(filter)
         .orderBy(primary, tiebreaker)
         .limit(query.limit)
         .offset(query.offset),
-      this.db.select({ value: count() }).from(notes),
+      this.db.select({ value: count() }).from(notes).where(filter),
     ]);
 
-    return { notes: rows.map((row) => rowToNote(row)), total };
+    const tagsByNote = await this.loadTags(rows.map((row) => row.id));
+    return {
+      notes: rows.map((row) => rowToNote(row, tagsByNote.get(row.id) ?? [])),
+      total,
+    };
+  }
+
+  async listTags(): Promise<readonly NoteTagCount[]> {
+    const rows = await this.db
+      .select({ tag: noteTags.tag, value: count() })
+      .from(noteTags)
+      .groupBy(noteTags.tag)
+      .orderBy(desc(count()), asc(noteTags.tag));
+    return rows.map((row) => ({ tag: row.tag, count: row.value }));
   }
 
   async listSourceHashes(): Promise<ReadonlyMap<string, string>> {
@@ -59,5 +89,24 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
       .select({ slug: notes.slug, sourceHash: notes.sourceHash })
       .from(notes);
     return new Map(rows.map((row) => [row.slug, row.sourceHash]));
+  }
+
+  /** 指定ノート群のタグを id → NoteTag[] にまとめて読み込む。 */
+  private async loadTags(
+    noteIds: readonly string[],
+  ): Promise<Map<string, NoteTag[]>> {
+    const map = new Map<string, NoteTag[]>();
+    if (noteIds.length === 0) return map;
+    const rows = await this.db
+      .select({ noteId: noteTags.noteId, tag: noteTags.tag })
+      .from(noteTags)
+      .where(inArray(noteTags.noteId, [...noteIds]))
+      .orderBy(asc(noteTags.tag));
+    for (const row of rows) {
+      const list = map.get(row.noteId) ?? [];
+      list.push(NoteTag.create(row.tag));
+      map.set(row.noteId, list);
+    }
+    return map;
   }
 }

--- a/app/backend/infra/d1/schema/index.ts
+++ b/app/backend/infra/d1/schema/index.ts
@@ -1,2 +1,3 @@
+export { noteTags } from "./note-tags";
 export { notes } from "./notes";
 export { users } from "./users";

--- a/app/backend/infra/d1/schema/note-tags.ts
+++ b/app/backend/infra/d1/schema/note-tags.ts
@@ -1,0 +1,24 @@
+import { index, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { notes } from "./notes";
+
+/**
+ * ノートとタグの関連 (正規化)。1 ノートが複数タグを持つ。
+ *
+ * - (note_id, tag) の複合主キーで同一タグの重複を防ぐ。
+ * - note 削除時のカスケード用に FK を張るが、D1 は FK 強制が既定で無効なため、
+ *   Command リポジトリ側でも明示的に note_tags を掃除する。
+ * - tag での絞り込み・集計 (タグ索引) のため tag に index を張る。
+ */
+export const noteTags = sqliteTable(
+  "note_tags",
+  {
+    noteId: text("note_id")
+      .notNull()
+      .references(() => notes.id, { onDelete: "cascade" }),
+    tag: text("tag").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.noteId, table.tag] }),
+    index("note_tags_tag_idx").on(table.tag),
+  ],
+);

--- a/app/backend/infra/github/github-content-store.ts
+++ b/app/backend/infra/github/github-content-store.ts
@@ -74,7 +74,12 @@ export class GitHubContentStore implements IContentStore {
 
   async listTree(): Promise<readonly ContentEntry[]> {
     const url = `${this.repoPath()}/git/trees/${encodeURIComponent(this.branch)}?recursive=1`;
-    const response = await this.fetchFn(url, { headers: await this.headers() });
+    // cache: "no-store" で Workers の fetch キャッシュを回避する。これが無いと
+    // push 後も古いツリー/内容が返り、refresh の変更検出が取りこぼす。
+    const response = await this.fetchFn(url, {
+      headers: await this.headers(),
+      cache: "no-store",
+    });
     if (!response.ok) {
       throw new GitHubRequestError(response.status, await safeText(response));
     }
@@ -95,6 +100,7 @@ export class GitHubContentStore implements IContentStore {
         // raw メディアタイプで生バイトを直接受け取る (base64 復号不要)。
         Accept: "application/vnd.github.raw+json",
       },
+      cache: "no-store",
     });
     if (response.status === HTTP_NOT_FOUND) return undefined;
     if (!response.ok) {

--- a/app/backend/services/note-content-parser.test.ts
+++ b/app/backend/services/note-content-parser.test.ts
@@ -4,6 +4,7 @@ import { extractSummary, parseNoteContent } from "./note-content-parser";
 const withFrontmatter = `---
 title: My Note
 imageUrl: ./cover.png
+tags: [日記, プログラミング]
 publishedOn: 2026-01-15
 lastModifiedOn: 2026-01-20
 ---
@@ -21,6 +22,7 @@ describe("parseNoteContent", () => {
     expect(frontmatter).toEqual({
       title: "My Note",
       imageUrl: "./cover.png",
+      tags: ["日記", "プログラミング"],
       publishedOn: "2026-01-15",
       lastModifiedOn: "2026-01-20",
     });

--- a/app/backend/services/note-content-parser.ts
+++ b/app/backend/services/note-content-parser.ts
@@ -14,6 +14,7 @@ const markdownProcessor = unified().use(remarkParse).use(remarkGfm);
 export interface NoteFrontmatter {
   readonly title: string | undefined;
   readonly imageUrl: string | undefined;
+  readonly tags: readonly string[];
   readonly publishedOn: string | undefined;
   readonly lastModifiedOn: string | undefined;
 }
@@ -41,6 +42,7 @@ export function parseNoteContent(markdown: string): ParsedNoteContent {
     frontmatter: {
       title: asOptionalString(rawMatter.title),
       imageUrl: asOptionalString(rawMatter.imageUrl),
+      tags: asStringArray(rawMatter.tags),
       publishedOn: asDateString(rawMatter.publishedOn),
       lastModifiedOn: asDateString(rawMatter.lastModifiedOn),
     },
@@ -83,6 +85,24 @@ function isSummaryNode(node: RootContent): boolean {
 
 function asOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * フロントマターの tags を文字列配列に正規化する。配列以外は空配列に、各要素は
+ * trim し空文字を除き、重複を除去する (定義順は保つ)。
+ */
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (trimmed.length === 0 || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
 }
 
 /**

--- a/app/backend/services/notes-refresh.service.ts
+++ b/app/backend/services/notes-refresh.service.ts
@@ -9,7 +9,13 @@ import type {
   INoteQueryRepository,
 } from "~/backend/domain/note";
 import type { IUnpersisted } from "~/backend/domain/shared";
-import { ImageUrl, Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import {
+  ImageUrl,
+  Note,
+  NoteSlug,
+  NoteTag,
+  NoteTitle,
+} from "~/backend/domain/note";
 
 const noteSourcePattern = /^notes\/[^/]+\.md$/;
 
@@ -235,6 +241,7 @@ function buildNoteContent(
       title: NoteTitle.create(parsed.frontmatter.title ?? group.base),
       summary: parsed.summary,
       imageUrl,
+      tags: parsed.frontmatter.tags.map((tag) => NoteTag.create(tag)),
       publishedOn,
       lastModifiedOn,
       sourceHash: group.contentHash,

--- a/app/frontend/components/layout/header.tsx
+++ b/app/frontend/components/layout/header.tsx
@@ -30,6 +30,18 @@ export function Header({ variant = "solid" }: HeaderProps): React.JSX.Element {
             >
               Home
             </Link>
+            <Link
+              href="/notes"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+            >
+              Notes
+            </Link>
+            <Link
+              href="/tags"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+            >
+              Tags
+            </Link>
           </nav>
         </div>
       </div>

--- a/app/frontend/pages/notes/index.tsx
+++ b/app/frontend/pages/notes/index.tsx
@@ -10,6 +10,7 @@ interface PublicNote {
   readonly title: string;
   readonly summary: string;
   readonly imageUrl: string | null;
+  readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
 }
@@ -22,6 +23,8 @@ interface NotesIndexProps extends PageProps {
     readonly total: number;
     readonly totalPages: number;
   };
+  /** 絞り込み中のタグ (未絞り込みなら null)。 */
+  readonly tag: string | null;
   readonly sort: {
     readonly sortBy: string | null;
     readonly order: string | null;
@@ -38,12 +41,14 @@ function buildHrefForPage(
   page: number,
   perPage: number,
   sort: NotesIndexProps["sort"],
+  tag: string | null,
 ): string {
   const params = new URLSearchParams();
   if (page > 1) params.set("page", String(page));
   if (perPage !== DEFAULT_PER_PAGE) params.set("per-page", String(perPage));
   if (sort.sortBy !== null) params.set("sort-by", sort.sortBy);
   if (sort.order !== null) params.set("order", sort.order);
+  if (tag !== null) params.set("tag", tag);
   const query = params.toString();
   return query.length > 0 ? `/notes?${query}` : "/notes";
 }
@@ -51,18 +56,29 @@ function buildHrefForPage(
 export default function NotesIndex({
   notes,
   pagination,
+  tag,
   sort,
 }: NotesIndexProps): React.JSX.Element {
   const { t } = useTranslation();
   const hrefForPage = (page: number): string =>
-    buildHrefForPage(page, pagination.perPage, sort);
+    buildHrefForPage(page, pagination.perPage, sort, tag);
 
   return (
     <AppLayout>
       <Head title={t("notes.title")} />
       <Header />
       <main className="mx-auto max-w-3xl px-6 py-10">
-        <h1 className="text-3xl font-bold">{t("notes.heading")}</h1>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h1 className="text-3xl font-bold">{t("notes.heading")}</h1>
+          {tag !== null && (
+            <span className="text-base-content/70">
+              {t("notes.filteredByTag", { tag })}
+              <Link href="/notes" className="link link-primary ml-2 text-sm">
+                {t("notes.clearFilter")}
+              </Link>
+            </span>
+          )}
+        </div>
 
         {notes.length === 0 ? (
           <p className="mt-8 text-base-content/60">{t("notes.empty")}</p>
@@ -96,6 +112,15 @@ export default function NotesIndex({
                     <p className="line-clamp-2 text-base-content/80">
                       {note.summary}
                     </p>
+                    {note.tags.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1.5">
+                        {note.tags.map((tg) => (
+                          <span key={tg} className="badge badge-sm badge-ghost">
+                            {tg}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </Link>
               </li>

--- a/app/frontend/pages/notes/show.tsx
+++ b/app/frontend/pages/notes/show.tsx
@@ -11,6 +11,7 @@ interface NoteMeta {
   readonly title: string;
   readonly summary: string;
   readonly imageUrl: string | null;
+  readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
 }
@@ -59,6 +60,19 @@ export default function NoteShow({
           >
             {note.publishedOn}
           </time>
+          {note.tags.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {note.tags.map((tg) => (
+                <Link
+                  key={tg}
+                  href={`/notes?tag=${encodeURIComponent(tg)}`}
+                  className="badge badge-outline gap-1 hover:badge-primary"
+                >
+                  {tg}
+                </Link>
+              ))}
+            </div>
+          )}
           {note.imageUrl !== null && (
             <img
               src={note.imageUrl}

--- a/app/frontend/pages/tags/index.tsx
+++ b/app/frontend/pages/tags/index.tsx
@@ -1,0 +1,46 @@
+import { Head, Link } from "@inertiajs/react";
+import { useTranslation } from "react-i18next";
+import type { PageProps } from "~/frontend/page-props";
+import { Header } from "~/frontend/components/layout/header";
+import { AppLayout } from "~/frontend/layouts/app-layout";
+
+interface TagCount {
+  readonly tag: string;
+  readonly count: number;
+}
+
+interface TagsIndexProps extends PageProps {
+  readonly tags: readonly TagCount[];
+}
+
+export default function TagsIndex({ tags }: TagsIndexProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <AppLayout>
+      <Head title={t("tags.title")} />
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-10">
+        <h1 className="text-3xl font-bold">{t("tags.heading")}</h1>
+
+        {tags.length === 0 ? (
+          <p className="mt-8 text-base-content/60">{t("tags.empty")}</p>
+        ) : (
+          <ul className="mt-8 flex flex-wrap gap-3">
+            {tags.map(({ tag, count }) => (
+              <li key={tag}>
+                <Link
+                  href={`/notes?tag=${encodeURIComponent(tag)}`}
+                  className="badge badge-lg badge-outline gap-2 py-3 hover:badge-primary"
+                >
+                  <span>{tag}</span>
+                  <span className="text-xs opacity-60">{count}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </AppLayout>
+  );
+}

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -10,10 +10,17 @@
     "viewNotes": "View notes",
     "logout": "Log out"
   },
+  "tags": {
+    "title": "Tags",
+    "heading": "Tags",
+    "empty": "No tags yet."
+  },
   "notes": {
     "title": "Notes",
     "heading": "Notes",
     "empty": "No notes have been published yet.",
+    "filteredByTag": "Tagged “{{tag}}”",
+    "clearFilter": "Show all",
     "pagination": {
       "label": "Pagination",
       "previous": "Previous page",

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -10,10 +10,17 @@
     "viewNotes": "ノートを見る",
     "logout": "ログアウト"
   },
+  "tags": {
+    "title": "タグ",
+    "heading": "タグ",
+    "empty": "タグがまだない。"
+  },
   "notes": {
     "title": "ノート",
     "heading": "ノート",
     "empty": "まだ公開されたノートがない。",
+    "filteredByTag": "タグ「{{tag}}」",
+    "clearFilter": "すべて表示",
     "pagination": {
       "label": "ページ送り",
       "previous": "前のページ",

--- a/migrations/0003_create_note_tags_table.sql
+++ b/migrations/0003_create_note_tags_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `note_tags` (
+	`note_id` text NOT NULL,
+	`tag` text NOT NULL,
+	PRIMARY KEY(`note_id`, `tag`),
+	FOREIGN KEY (`note_id`) REFERENCES `notes`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `note_tags_tag_idx` ON `note_tags` (`tag`);

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,201 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b5119c8b-6c9b-4c3b-960c-08c4ac30e240",
+  "prevId": "fd6694ca-26e9-496c-8ed9-96e8acf0cee4",
+  "tables": {
+    "note_tags": {
+      "name": "note_tags",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_tags_tag_idx": {
+          "name": "note_tags_tag_idx",
+          "columns": ["tag"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_tags_note_id_notes_id_fk": {
+          "name": "note_tags_note_id_notes_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "notes",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_tags_note_id_tag_pk": {
+          "columns": ["note_id", "tag"],
+          "name": "note_tags_note_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783223392342,
       "tag": "0002_add_notes_source_hash",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1783308870518,
+      "tag": "0003_create_note_tags_table",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要
旧 Jekyll ブログにあったタグ機能を新システムに実装し、移植コンテンツにもタグを復活。Closes #31

## 変更
- **ドメイン**: `NoteTag` VO / `Note.tags`
- **D1**: `note_tags` テーブル (正規化) + migration 0003。command repo が upsert 時に入れ替え・delete 時に掃除。query repo が tags 読み込み・タグ絞り込み・`listTags` (件数集計)
- **サービス**: frontmatter `tags` をパース (trim/重複除去)、refresh が `NoteTag` として永続化
- **API/ページ**: `/notes?tag=<タグ>` 絞り込み、`/tags` タグ索引、`/api/v1/tags`。一覧/詳細にタグ chip (詳細は絞り込みリンク)、ヘッダに Notes/Tags リンク
- **fix**: `GitHubContentStore` の fetch を `cache: no-store` に (Workers の GET キャッシュで push 後の内容が古く返り refresh が取りこぼしていた)
- **コンテンツ**: `yantene/notes` の全 27 記事に旧タグを復活

## 確認 (staging・migration 0003 適用済み)
refresh → **全 27 記事同期・タグ 10 種/56 付与**が旧ブログと完全一致。`/tags` 200・`?tag=GNU/Linux`→7 件・詳細のタグ表示 OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)