### PR TITLE
fix: Chrome DevTools MCP に --no-sandbox を渡して起動不能を解消

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,9 @@
         "--headless",
         "--executablePath",
         "/usr/bin/chromium",
-        "--isolated"
+        "--isolated",
+        "--chromeArg=--no-sandbox",
+        "--chromeArg=--disable-setuid-sandbox"
       ]
     }
   }


### PR DESCRIPTION
## 概要

Chrome DevTools MCP (`mcp__chrome-devtools__*`) のツールが `Protocol error (Target.setDiscoverTargets): Target closed` で全て失敗していた問題を修正する。

Closes #34

## 原因

このコンテナ環境 (Talos Linux) は unprivileged user namespaces が無効化されており、Chromium が自前の sandbox を起動できない。

```
No usable sandbox! ... you can try using --no-sandbox.
```

`.mcp.json` の起動引数に `--no-sandbox` が無いため、ツール呼び出しのたびに Chromium が起動直後にクラッシュ (`chrome_crashpad` ゾンビ多数) し `Target closed` になっていた。

## 対応

chrome-devtools-mcp 公式 help 記載の方法で、sandbox 無効化オプションを chromeArg として付与する。

```
--chromeArg=--no-sandbox
--chromeArg=--disable-setuid-sandbox
```

headless かつ isolated な使い捨て Chromium なので、この用途では `--no-sandbox` は許容範囲。`--no-sandbox` 付きで Chromium が正常起動 (EXIT=0, DOM 取得) することを確認済み。

## 反映

マージ後、MCP を再接続 (`/mcp` reconnect または Claude Code 再起動) すると `mcp__chrome-devtools__*` ツールが動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)