### PR TITLE
feat: 共通ノートカード + ホーム新着6件グリッド

### DIFF
--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -2,9 +2,11 @@ import { inertia } from "@hono/inertia";
 import { Hono } from "hono";
 import { createLogoutRouter } from "~/backend/handlers/auth/logout.handler";
 import { createMagicLinkRouter } from "~/backend/handlers/auth/magic-link.handler";
+import { toPublicNote } from "~/backend/handlers/note-view";
 import { createNoteDetailPagesRouter } from "~/backend/handlers/notes/detail.handler";
 import { createNotesPagesRouter } from "~/backend/handlers/notes/pages.handler";
 import { createTagsPagesRouter } from "~/backend/handlers/notes/tags.handler";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
 import {
   type LocaleVariables,
   localeMiddleware,
@@ -22,8 +24,20 @@ export function createPagesRouter(): Hono<PagesBindings> {
   router.use("*", localeMiddleware);
   router.use(inertia({ rootView }));
 
-  // ホーム (公開・認証不要)。発信のハブとしてノート一覧への導線を持つ。
-  router.get("/", (c) => c.render("home", { locale: c.get("locale") }));
+  // ホーム (公開・認証不要)。Hero + 新着ノート 6 件を発信ハブとして表示する。
+  router.get("/", async (c) => {
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const result = await query.list({
+      limit: 6,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    return c.render("home", {
+      locale: c.get("locale"),
+      notes: result.notes.map((note) => toPublicNote(note)),
+    });
+  });
 
   // ログイン UI + magic link + logout。現状ログインは休眠 (将来の有料記事用に温存)。
   router.get("/login", (c) =>

--- a/app/frontend/app.css
+++ b/app/frontend/app.css
@@ -37,5 +37,7 @@
       YuGothic, Meiryo, system-ui, sans-serif;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
+    /* スクロールバー領域を常に確保し、ページ間で中央寄せが左右にズレないようにする。 */
+    scrollbar-gutter: stable;
   }
 }

--- a/app/frontend/components/layout/header.tsx
+++ b/app/frontend/components/layout/header.tsx
@@ -17,9 +17,7 @@ export function Header({ variant = "solid" }: HeaderProps): React.JSX.Element {
       }
     >
       <div className={isTransparent ? "" : "bg-white/60 backdrop-blur-sm"}>
-        <div
-          className={`mx-auto flex ${isTransparent ? "max-w-5xl" : "max-w-3xl"} items-center justify-between px-6 py-4`}
-        >
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <TypewriterTitle
             className={`text-xl font-bold tracking-tight text-foreground${isTransparent ? " text-halo" : ""}`}
           />

--- a/app/frontend/components/note-card/note-card.stories.tsx
+++ b/app/frontend/components/note-card/note-card.stories.tsx
@@ -1,0 +1,37 @@
+import { NoteCard } from "./note-card";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof NoteCard> = {
+  title: "NoteCard/NoteCard",
+  component: NoteCard,
+  parameters: { layout: "centered" },
+  args: {
+    slug: "hello-world",
+    title: "はじめてのノート",
+    summary:
+      "これはノートの要約です。一覧やホームの新着カードに、先頭 160 文字ほどが表示されます。",
+    imageUrl: null,
+    tags: ["日記", "プログラミング"],
+    publishedOn: "2026-01-15",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Placeholder: Story = {};
+
+export const WithImage: Story = {
+  args: { imageUrl: "https://picsum.photos/seed/yantene/640/360" },
+};
+
+export const NoTags: Story = {
+  args: { tags: [] },
+};

--- a/app/frontend/components/note-card/note-card.tsx
+++ b/app/frontend/components/note-card/note-card.tsx
@@ -1,0 +1,68 @@
+import { Link } from "@inertiajs/react";
+
+export interface NoteCardProps {
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly imageUrl: string | null;
+  readonly tags: readonly string[];
+  readonly publishedOn: string;
+}
+
+/**
+ * ノート一覧・ホーム新着で使い回す縦型カード。カード全体がノート詳細へのリンク。
+ * カード内はリンクを入れ子にできないため、タグは表示のみ (絞り込みは詳細ページで)。
+ */
+export function NoteCard({
+  slug,
+  title,
+  summary,
+  imageUrl,
+  tags,
+  publishedOn,
+}: NoteCardProps): React.JSX.Element {
+  return (
+    <Link
+      href={`/notes/${slug}`}
+      className="group flex flex-col overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm transition-all hover:border-primary/40 hover:shadow-md"
+    >
+      <figure className="aspect-video overflow-hidden">
+        {imageUrl === null ? (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/15 to-secondary/15">
+            <span className="text-4xl font-bold text-primary/40">
+              {title.charAt(0) || "?"}
+            </span>
+          </div>
+        ) : (
+          <img
+            src={imageUrl}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        )}
+      </figure>
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <time dateTime={publishedOn} className="text-xs text-base-content/60">
+          {publishedOn}
+        </time>
+        <h3 className="line-clamp-2 font-bold leading-snug transition-colors group-hover:text-primary">
+          {title}
+        </h3>
+        <p className="line-clamp-2 flex-1 text-sm text-base-content/70">
+          {summary}
+        </p>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {tags.map((tag) => (
+              <span key={tag} className="badge badge-sm badge-ghost">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,11 +1,21 @@
-import { Head } from "@inertiajs/react";
+import { Head, Link } from "@inertiajs/react";
 import { useTranslation } from "react-i18next";
+import type { PageProps } from "~/frontend/page-props";
 import { HeroSection } from "~/frontend/components/hero/hero-section";
 import { Footer } from "~/frontend/components/layout/footer";
 import { Header } from "~/frontend/components/layout/header";
+import {
+  NoteCard,
+  type NoteCardProps,
+} from "~/frontend/components/note-card/note-card";
 import { AppLayout } from "~/frontend/layouts/app-layout";
 
-export default function Home(): React.JSX.Element {
+interface HomeProps extends PageProps {
+  /** 新着ノート (公開日降順・最大 6 件)。 */
+  readonly notes: readonly NoteCardProps[];
+}
+
+export default function Home({ notes }: HomeProps): React.JSX.Element {
   const { t } = useTranslation();
 
   return (
@@ -16,6 +26,23 @@ export default function Home(): React.JSX.Element {
       {/* 透過ヘッダを Celestim ヒーローの上に重ねる。ヒーローは pt で頭を空けている。 */}
       <Header variant="transparent" />
       <HeroSection />
+
+      {notes.length > 0 && (
+        <section className="mx-auto w-full max-w-5xl flex-1 px-6 py-16">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-2xl font-bold">{t("home.recentNotes")}</h2>
+            <Link href="/notes" className="link link-primary text-sm">
+              {t("home.viewAll")}
+            </Link>
+          </div>
+          <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {notes.map((note) => (
+              <NoteCard key={note.slug} {...note} />
+            ))}
+          </div>
+        </section>
+      )}
+
       <Footer />
     </AppLayout>
   );

--- a/app/frontend/pages/notes/index.tsx
+++ b/app/frontend/pages/notes/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { PageProps } from "~/frontend/page-props";
 import { Footer } from "~/frontend/components/layout/footer";
 import { Header } from "~/frontend/components/layout/header";
+import { NoteCard } from "~/frontend/components/note-card/note-card";
 import { Pagination } from "~/frontend/components/pagination/pagination";
 import { AppLayout } from "~/frontend/layouts/app-layout";
 
@@ -68,7 +69,7 @@ export default function NotesIndex({
     <AppLayout>
       <Head title={t("notes.title")} />
       <Header />
-      <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-10">
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-10">
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <h1 className="text-3xl font-bold">{t("notes.heading")}</h1>
           {tag !== null && (
@@ -84,55 +85,11 @@ export default function NotesIndex({
         {notes.length === 0 ? (
           <p className="mt-8 text-base-content/60">{t("notes.empty")}</p>
         ) : (
-          <ul className="mt-8 flex flex-col gap-4">
+          <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {notes.map((note) => (
-              <li key={note.slug}>
-                <Link
-                  href={`/notes/${note.slug}`}
-                  className="card card-side border border-base-300 bg-base-100 shadow-sm transition-all hover:border-primary/40 hover:shadow-md"
-                >
-                  <figure className="w-32 shrink-0">
-                    {note.imageUrl === null ? (
-                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/15 to-secondary/15">
-                        <span className="text-3xl font-bold text-primary/40">
-                          {note.title.charAt(0) || "?"}
-                        </span>
-                      </div>
-                    ) : (
-                      <img
-                        src={note.imageUrl}
-                        alt=""
-                        loading="lazy"
-                        decoding="async"
-                        className="h-full w-full object-cover"
-                      />
-                    )}
-                  </figure>
-                  <div className="card-body">
-                    <h2 className="card-title">{note.title}</h2>
-                    <time
-                      dateTime={note.publishedOn}
-                      className="text-sm text-base-content/60"
-                    >
-                      {note.publishedOn}
-                    </time>
-                    <p className="line-clamp-2 text-base-content/80">
-                      {note.summary}
-                    </p>
-                    {note.tags.length > 0 && (
-                      <div className="mt-1 flex flex-wrap gap-1.5">
-                        {note.tags.map((tg) => (
-                          <span key={tg} className="badge badge-sm badge-ghost">
-                            {tg}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </Link>
-              </li>
+              <NoteCard key={note.slug} {...note} />
             ))}
-          </ul>
+          </div>
         )}
 
         <div className="mt-10 flex justify-center">

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -6,6 +6,8 @@
   "home": {
     "heading": "yantene",
     "tagline": "A hub for everything yantene publishes",
+    "recentNotes": "Recent notes",
+    "viewAll": "View all",
     "welcome": "Welcome, {{name}}",
     "viewNotes": "View notes",
     "logout": "Log out"

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -6,6 +6,8 @@
   "home": {
     "heading": "yantene",
     "tagline": "yantene の発信を集約するハブ",
+    "recentNotes": "新着ノート",
+    "viewAll": "すべて見る",
     "welcome": "ようこそ、{{name}} さん",
     "viewNotes": "ノートを見る",
     "logout": "ログアウト"


### PR DESCRIPTION
Closes #36

## 変更
- **NoteCard** コンポーネント新設（縦型: 画像/プレースホルダ + タイトル/日付/要約/タグ）+ story
- **ホーム**: Hero の下に新着ノート6件を3列グリッド(Z 並び)で表示。バックエンド(home ルータ)が D1 から公開日降順6件を取得
- **/notes 一覧**: card-side から NoteCard グリッドに統一、幅 max-w-5xl
- ヘッダ幅を max-w-5xl に統一

## 確認
staging 反映済み。ホーム・一覧でカードグリッド表示、全ページ 200。