### PR TITLE
chore: 未使用 i18n キーと Storybook の dark 参照を掃除

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,7 +23,6 @@ const preview: Preview = {
     withThemeByDataAttribute<Renderer>({
       themes: {
         light: "light",
-        dark: "dark",
       },
       defaultTheme: "light",
       attributeName: "data-theme",

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -7,10 +7,7 @@
     "heading": "yantene",
     "tagline": "A hub for everything yantene publishes",
     "recentNotes": "Recent notes",
-    "viewAll": "View all",
-    "welcome": "Welcome, {{name}}",
-    "viewNotes": "View notes",
-    "logout": "Log out"
+    "viewAll": "View all"
   },
   "tags": {
     "title": "Tags",

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -7,10 +7,7 @@
     "heading": "yantene",
     "tagline": "yantene の発信を集約するハブ",
     "recentNotes": "新着ノート",
-    "viewAll": "すべて見る",
-    "welcome": "ようこそ、{{name}} さん",
-    "viewNotes": "ノートを見る",
-    "logout": "ログアウト"
+    "viewAll": "すべて見る"
   },
   "tags": {
     "title": "タグ",


### PR DESCRIPTION
Closes #41。ダークモード撤去・ホーム刷新で不要になった home.welcome/viewNotes/logout を削除。Storybook の dark テーマ参照を削除。