### PR TITLE
feat: OGP メタタグ + デフォルト OG 画像

### DIFF
--- a/app/backend/handlers/notes/detail.handler.ts
+++ b/app/backend/handlers/notes/detail.handler.ts
@@ -98,6 +98,12 @@ export function createNoteDetailPagesRouter(): Hono<{
       locale: c.get("locale"),
       note: detail.note,
       mdast: detail.mdast,
+      og: {
+        title: detail.note.title,
+        description: detail.note.summary,
+        image: `/og/notes/${detail.note.slug}`,
+        type: "article",
+      },
     });
   });
 

--- a/app/backend/handlers/notes/pages.handler.ts
+++ b/app/backend/handlers/notes/pages.handler.ts
@@ -45,6 +45,7 @@ export function createNotesPagesRouter(): Hono<NotesPagesBindings> {
         sortBy: c.req.query("sort-by") ?? null,
         order: c.req.query("order") ?? null,
       },
+      og: { image: "/og/default", type: "website" },
     });
   });
 

--- a/app/backend/handlers/notes/tags.handler.ts
+++ b/app/backend/handlers/notes/tags.handler.ts
@@ -17,7 +17,11 @@ export function createTagsPagesRouter(): Hono<TagsPagesBindings> {
   router.get("/tags", async (c) => {
     const query = new D1NoteQueryRepository(c.env.D1);
     const tags = await query.listTags();
-    return c.render("tags/index", { locale: c.get("locale"), tags });
+    return c.render("tags/index", {
+      locale: c.get("locale"),
+      tags,
+      og: { image: "/og/default", type: "website" },
+    });
   });
 
   return router;

--- a/app/backend/handlers/og.handler.ts
+++ b/app/backend/handlers/og.handler.ts
@@ -76,13 +76,66 @@ function cardHtml(params: {
     </div>`;
 }
 
+/** サイト共通のデフォルト OG カード (記事以外のページ用)。 */
+function defaultCardHtml(): string {
+  return `
+    <div style="display:flex;flex-direction:column;width:1200px;height:630px;background:#ffffff;font-family:'Noto Sans JP';">
+      <div style="display:flex;height:14px;width:100%;background:linear-gradient(90deg,#c9f2ff,#ffad31,#28324f,#db6a00,#c9f2ff);"></div>
+      <div style="display:flex;flex:1;flex-direction:column;align-items:center;justify-content:center;">
+        <img src="${ICON_DATA_URI}" width="132" height="132" style="border-radius:26px;" />
+        <div style="display:flex;font-size:84px;font-weight:700;color:#1a1a1a;margin-top:28px;">yantene</div>
+        <div style="display:flex;font-size:30px;color:#999999;margin-top:14px;">yantene の発信を集約するハブ</div>
+      </div>
+    </div>`;
+}
+
+const imageHeaders = {
+  "Content-Type": "image/png",
+  "Cache-Control": "public, max-age=31536000, immutable",
+};
+
+/** HTML を OG 画像 (PNG) にして R2 にキャッシュし返す。既存キャッシュがあれば即返す。 */
+async function renderAndCache(
+  env: Env,
+  cacheKey: string,
+  html: string,
+): Promise<Response> {
+  const cached = await env.R2.get(cacheKey);
+  if (cached !== null) {
+    return new Response(cached.body, { headers: imageHeaders });
+  }
+  // workers-og は WASM を含むため動的 import する (トップレベル import だと
+  // index.ts を読むだけで WASM ロードが走り、テスト環境が壊れる)。
+  const { ImageResponse } = await import("workers-og");
+  const font = await loadFont(env);
+  const image = new ImageResponse(html, {
+    width: 1200,
+    height: 630,
+    fonts: [{ name: "Noto Sans JP", data: font, weight: 700, style: "normal" }],
+  });
+  const bytes = await image.arrayBuffer();
+  await env.R2.put(cacheKey, bytes, {
+    httpMetadata: { contentType: "image/png" },
+  });
+  return new Response(bytes, { headers: imageHeaders });
+}
+
 /**
- * OG 画像の生成ルータ (公開)。`GET /og/notes/:slug` が 1200x630 の PNG を返す。
- * imageUrl の有無に関わらず常にブランドカードを生成する。R2 にキャッシュし、
- * 記事内容が変わったら sourceHash 込みのキーで自動的に再生成される。
+ * OG 画像の生成ルータ (公開)。
+ * - GET /og/notes/:slug → 記事のブランドカード (imageUrl 有無に関わらず常に生成)
+ * - GET /og/default     → サイト共通のデフォルトカード
+ * R2 にキャッシュし、記事更新やテンプレ版変更で自動再生成する。
  */
 export function createOgRouter(): Hono<{ Bindings: Env }> {
   const router = new Hono<{ Bindings: Env }>();
+
+  router.get("/default", (c) =>
+    renderAndCache(
+      c.env,
+      `og/default-${OG_TEMPLATE_VERSION}.png`,
+      defaultCardHtml(),
+    ),
+  );
 
   router.get("/notes/:slug", async (c) => {
     let slug: NoteSlug;
@@ -95,38 +148,16 @@ export function createOgRouter(): Hono<{ Bindings: Env }> {
     const note = await new D1NoteQueryRepository(c.env.D1).findBySlug(slug);
     if (note === undefined) return c.notFound();
 
-    const cacheKey = `og/notes/${slug.toString()}-${note.sourceHash}-${OG_TEMPLATE_VERSION}.png`;
-    const cached = await c.env.R2.get(cacheKey);
-    const headers = {
-      "Content-Type": "image/png",
-      "Cache-Control": "public, max-age=31536000, immutable",
-    };
-    if (cached !== null) {
-      return new Response(cached.body, { headers });
-    }
-
-    // workers-og は WASM を含むため動的 import する (トップレベル import だと
-    // index.ts を読むだけで WASM ロードが走り、テスト環境が壊れる)。
-    const { ImageResponse } = await import("workers-og");
-    const font = await loadFont(c.env);
     const html = cardHtml({
       title: note.title.toString(),
       date: note.publishedOn.toString({ calendarName: "never" }),
       tags: note.tags.map((tag) => tag.toString()),
     });
-    const image = new ImageResponse(html, {
-      width: 1200,
-      height: 630,
-      fonts: [
-        { name: "Noto Sans JP", data: font, weight: 700, style: "normal" },
-      ],
-    });
-
-    const bytes = await image.arrayBuffer();
-    await c.env.R2.put(cacheKey, bytes, {
-      httpMetadata: { contentType: "image/png" },
-    });
-    return new Response(bytes, { headers });
+    return renderAndCache(
+      c.env,
+      `og/notes/${slug.toString()}-${note.sourceHash}-${OG_TEMPLATE_VERSION}.png`,
+      html,
+    );
   });
 
   return router;

--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -36,6 +36,7 @@ export function createPagesRouter(): Hono<PagesBindings> {
     return c.render("home", {
       locale: c.get("locale"),
       notes: result.notes.map((note) => toPublicNote(note)),
+      og: { image: "/og/default", type: "website" },
     });
   });
 

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -10,12 +10,30 @@ import { renderPage } from "~/frontend/entry.server";
 import { isSupportedLocale, type SupportedLocale } from "~/lib/i18n/locale";
 import resources from "~/lib/i18n/locales";
 
+/** ページが props で渡す OGP メタ (省略時はサイト既定にフォールバック)。 */
+interface PageOg {
+  readonly title?: string;
+  readonly description?: string;
+  /** OG 画像の相対パス (例: "/og/notes/foo")。root-view で絶対 URL 化する。 */
+  readonly image?: string;
+  readonly type?: string;
+}
+
+interface OgValues {
+  readonly title: string;
+  readonly description: string;
+  readonly image: string;
+  readonly url: string;
+  readonly type: string;
+}
+
 interface HeadProps {
   readonly title: string;
   readonly description: string;
+  readonly og: OgValues;
 }
 
-function Head({ title, description }: HeadProps): React.JSX.Element {
+function Head({ title, description, og }: HeadProps): React.JSX.Element {
   return (
     <>
       <meta charSet="utf-8" />
@@ -24,6 +42,17 @@ function Head({ title, description }: HeadProps): React.JSX.Element {
       <meta name="description" content={description} />
       <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
       <link rel="manifest" href="/manifest.webmanifest" />
+      <meta property="og:site_name" content="yantene" />
+      <meta property="og:locale" content="ja_JP" />
+      <meta property="og:title" content={og.title} />
+      <meta property="og:description" content={og.description} />
+      <meta property="og:image" content={og.image} />
+      <meta property="og:url" content={og.url} />
+      <meta property="og:type" content={og.type} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={og.title} />
+      <meta name="twitter:description" content={og.description} />
+      <meta name="twitter:image" content={og.image} />
       <ViteClient />
       <ReactRefresh />
       <Link href="/app/frontend/app.css" rel="stylesheet" />
@@ -39,16 +68,28 @@ function resolveLocale(page: {
   return typeof value === "string" && isSupportedLocale(value) ? value : "en";
 }
 
-export const rootView: RootView = async (page) => {
+export const rootView: RootView = async (page, c) => {
   const locale = resolveLocale(page);
   // eslint-disable-next-line security/detect-object-injection -- locale is narrowed to SupportedLocale literal
   const translations = resources[locale].translation;
   const { meta } = translations;
 
+  // OGP は絶対 URL が要る。リクエスト URL から origin/pathname を組む。
+  const requestUrl = new URL(c.req.url);
+  const pageOg = (page.props.og ?? {}) as PageOg;
+  const og: OgValues = {
+    title: pageOg.title ?? meta.title,
+    description: pageOg.description ?? meta.description,
+    image: `${requestUrl.origin}${pageOg.image ?? "/og/default"}`,
+    url: `${requestUrl.origin}${requestUrl.pathname}`,
+    type: pageOg.type ?? "website",
+  };
+
   const { head, body } = await renderPage(page);
   const headHtml =
-    renderToString(<Head title={meta.title} description={meta.description} />) +
-    head.join("");
+    renderToString(
+      <Head title={meta.title} description={meta.description} og={og} />,
+    ) + head.join("");
 
   // body には Inertia の SSR 出力 (<script data-page="app"> + <div id="app">) が
   // すでに含まれている。ここで <div id="app"> を重ねて巻くと id が重複し、


### PR DESCRIPTION
Closes #44。全ページに og:/twitter: メタタグを SSR 出力 (記事は専用 OG カード、その他はデフォルト)。og:image/url は絶対 URL。GET /og/default 追加。

staging 確認済み: 記事ページに og:title/image(article) / ホーム・一覧・タグに og:image=/og/default。