### PR TITLE
feat: Atom フィード /feed.xml

### DIFF
--- a/app/backend/handlers/feed.handler.test.ts
+++ b/app/backend/handlers/feed.handler.test.ts
@@ -1,0 +1,60 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import type { IUnpersisted } from "~/backend/domain/shared";
+import { Note, NoteSlug, NoteTitle } from "~/backend/domain/note";
+import app from "~/backend/index";
+import { D1NoteCommandRepository } from "~/backend/infra/d1/repositories";
+import { createTestD1 } from "~/backend/infra/d1/test-helper";
+
+function unpersistedNote(params: {
+  slug: string;
+  title: string;
+  summary?: string;
+  publishedOn?: string;
+  lastModifiedOn?: string;
+}): Note<IUnpersisted> {
+  return Note.create({
+    slug: NoteSlug.create(params.slug),
+    title: NoteTitle.create(params.title),
+    summary: params.summary ?? "summary",
+    imageUrl: undefined,
+    publishedOn: Temporal.PlainDate.from(params.publishedOn ?? "2026-01-15"),
+    lastModifiedOn: Temporal.PlainDate.from(
+      params.lastModifiedOn ?? "2026-01-20",
+    ),
+    sourceHash: "hash-0",
+  });
+}
+
+function env(d1: D1Database): Env {
+  return { D1: d1, KV: {} } as unknown as Env;
+}
+
+describe("GET /feed.xml", () => {
+  it("returns an Atom feed with the correct content type", async () => {
+    const d1 = createTestD1();
+    const res = await app.request("/feed.xml", {}, env(d1));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/atom+xml");
+    const body = await res.text();
+    expect(body).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(body).toContain("<title>yantene.net</title>");
+  });
+
+  it("includes published notes as entries with absolute links", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      unpersistedNote({ slug: "hello-world", title: "Hello & World" }),
+    );
+
+    const res = await app.request("https://example.test/feed.xml", {}, env(d1));
+    const body = await res.text();
+
+    expect(body).toContain("<entry>");
+    expect(body).toContain("https://example.test/notes/hello-world");
+    // XML エスケープされていること
+    expect(body).toContain("Hello &amp; World");
+    expect(body).toContain("2026-01-15T00:00:00Z");
+  });
+});

--- a/app/backend/handlers/feed.handler.ts
+++ b/app/backend/handlers/feed.handler.ts
@@ -1,0 +1,90 @@
+import { Hono } from "hono";
+import { toPublicNote, type PublicNote } from "./note-view";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+const FEED_LIMIT = 20;
+const FEED_TITLE = "yantene.net";
+const FEED_SUBTITLE = "yantene の発信を集約するハブ";
+const FEED_AUTHOR = "yantene";
+/** ノートが 1 件も無いときの feed updated (Date に依存させない安全側の既定値)。 */
+const FALLBACK_UPDATED = "2026-01-01T00:00:00Z";
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** "YYYY-MM-DD" を Atom の RFC3339 日時に (UTC 0 時)。 */
+function toRfc3339(date: string): string {
+  return `${date}T00:00:00Z`;
+}
+
+function entryXml(origin: string, note: PublicNote): string {
+  const url = `${origin}/notes/${note.slug}`;
+  const categories = note.tags
+    .map((tag) => `    <category term="${escapeXml(tag)}"/>`)
+    .join("\n");
+  return `  <entry>
+    <title>${escapeXml(note.title)}</title>
+    <link href="${url}"/>
+    <id>${url}</id>
+    <published>${toRfc3339(note.publishedOn)}</published>
+    <updated>${toRfc3339(note.lastModifiedOn)}</updated>
+    <summary>${escapeXml(note.summary)}</summary>
+${categories}
+  </entry>`;
+}
+
+function buildAtom(origin: string, notes: readonly PublicNote[]): string {
+  // feed 全体の updated は最新の更新日時 (エントリの lastModifiedOn の最大)。
+  const updated =
+    notes
+      .map((note) => toRfc3339(note.lastModifiedOn))
+      .toSorted((a, b) => a.localeCompare(b))
+      .at(-1) ?? FALLBACK_UPDATED;
+  const entries = notes.map((note) => entryXml(origin, note)).join("\n");
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(FEED_TITLE)}</title>
+  <subtitle>${escapeXml(FEED_SUBTITLE)}</subtitle>
+  <link href="${origin}/feed.xml" rel="self" type="application/atom+xml"/>
+  <link href="${origin}/" rel="alternate" type="text/html"/>
+  <id>${origin}/</id>
+  <updated>${updated}</updated>
+  <author><name>${escapeXml(FEED_AUTHOR)}</name></author>
+${entries}
+</feed>
+`;
+}
+
+/**
+ * Atom フィードの公開ルータ。`GET /feed.xml` が最新ノートを Atom で返す。認証不要
+ * (フィードリーダー対応) なので index.ts で auth ガードより前にマウントする。
+ */
+export function createFeedRouter(): Hono<{ Bindings: Env }> {
+  const router = new Hono<{ Bindings: Env }>();
+
+  router.get("/feed.xml", async (c) => {
+    const result = await new D1NoteQueryRepository(c.env.D1).list({
+      limit: FEED_LIMIT,
+      offset: 0,
+      sortBy: "publishedOn",
+      direction: "desc",
+    });
+    const origin = new URL(c.req.url).origin;
+    const xml = buildAtom(
+      origin,
+      result.notes.map((note) => toPublicNote(note)),
+    );
+    return c.body(xml, 200, {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    });
+  });
+
+  return router;
+}

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -6,6 +6,7 @@ import {
   type SecureHeadersVariables,
 } from "hono/secure-headers";
 import { createApiRouter } from "./handlers/api";
+import { createFeedRouter } from "./handlers/feed.handler";
 import { createNoteAssetsRouter } from "./handlers/notes/assets.handler";
 import { createNoteDetailApiRouter } from "./handlers/notes/detail.handler";
 import { createNotesApiRouter } from "./handlers/notes/list-api.handler";
@@ -62,6 +63,7 @@ app.route("/api/v1/notes", createNoteDetailApiRouter());
 app.route("/api/v1/notes", createNoteAssetsRouter());
 app.route("/api/v1/tags", createTagsApiRouter());
 app.route("/og", createOgRouter());
+app.route("/", createFeedRouter());
 
 // ノート同期 (コンテンツ正本 → D1 + R2)。POST /api/v1/refresh。
 // session ではなく REFRESH_SECRET で保護する運用エンドポイントなので、requireSession

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -42,6 +42,12 @@ function Head({ title, description, og }: HeadProps): React.JSX.Element {
       <meta name="description" content={description} />
       <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
       <link rel="manifest" href="/manifest.webmanifest" />
+      <link
+        rel="alternate"
+        type="application/atom+xml"
+        title="yantene.net"
+        href="/feed.xml"
+      />
       <meta property="og:site_name" content="yantene.net" />
       <meta property="og:locale" content="ja_JP" />
       <meta property="og:title" content={og.title} />


### PR DESCRIPTION
Closes #49。D1 の最新 20 件を Atom で配信 (公開・認証不要)。head に alternate link。staging 確認済み (200 / application/atom+xml / 20 entries)。