### PR TITLE
feat: sitemap.xml + robots.txt + JSON-LD 構造化データ

### DIFF
--- a/app/backend/handlers/notes/detail.handler.ts
+++ b/app/backend/handlers/notes/detail.handler.ts
@@ -94,6 +94,7 @@ export function createNoteDetailPagesRouter(): Hono<{
       });
     }
 
+    const origin = new URL(c.req.url).origin;
     return c.render("notes/show", {
       locale: c.get("locale"),
       note: detail.note,
@@ -103,6 +104,20 @@ export function createNoteDetailPagesRouter(): Hono<{
         description: detail.note.summary,
         image: `/og/notes/${detail.note.slug}`,
         type: "article",
+      },
+      // schema.org BlogPosting (検索エンジン向け構造化データ)。絶対 URL で構築する。
+      jsonLd: {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        headline: detail.note.title,
+        description: detail.note.summary,
+        image: `${origin}/og/notes/${detail.note.slug}`,
+        datePublished: detail.note.publishedOn,
+        dateModified: detail.note.lastModifiedOn,
+        author: { "@type": "Person", name: "yantene", url: `${origin}/` },
+        publisher: { "@type": "Person", name: "yantene" },
+        mainEntityOfPage: `${origin}/notes/${detail.note.slug}`,
+        keywords: detail.note.tags,
       },
     });
   });

--- a/app/backend/handlers/seo.handler.ts
+++ b/app/backend/handlers/seo.handler.ts
@@ -1,0 +1,78 @@
+/* eslint-disable no-secrets/no-secrets -- XML/MIME 文字列を秘匿情報と誤検知するため無効化 (秘密は含まない)。 */
+import { Hono } from "hono";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+/** sitemap に載せるノート数の上限 (個人ブログ規模では十分)。 */
+const SITEMAP_NOTE_LIMIT = 10_000;
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function urlEntry(loc: string, lastmod?: string): string {
+  const lastmodTag =
+    lastmod === undefined ? "" : `<lastmod>${lastmod}</lastmod>`;
+  return `  <url><loc>${escapeXml(loc)}</loc>${lastmodTag}</url>`;
+}
+
+/**
+ * SEO 関連の公開ルータ。認証不要なので index.ts で auth ガードより前にマウントする。
+ * - GET /sitemap.xml : ホーム / 一覧 / タグ索引 / 全記事を列挙 (記事は lastmod つき)
+ * - GET /robots.txt  : production は sitemap を案内、staging (BASIC 認証あり) は全 Disallow
+ */
+export function createSeoRouter(): Hono<{ Bindings: Env }> {
+  const router = new Hono<{ Bindings: Env }>();
+
+  router.get("/sitemap.xml", async (c) => {
+    const origin = new URL(c.req.url).origin;
+    const result = await new D1NoteQueryRepository(c.env.D1).list({
+      limit: SITEMAP_NOTE_LIMIT,
+      offset: 0,
+      sortBy: "lastModifiedOn",
+      direction: "desc",
+    });
+
+    const staticUrls = [
+      urlEntry(`${origin}/`),
+      urlEntry(`${origin}/notes`),
+      urlEntry(`${origin}/tags`),
+    ];
+    const noteUrls = result.notes.map((note) =>
+      urlEntry(
+        `${origin}/notes/${note.slug.toJSON()}`,
+        note.lastModifiedOn.toString({ calendarName: "never" }),
+      ),
+    );
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${[...staticUrls, ...noteUrls].join("\n")}
+</urlset>
+`;
+    return c.body(xml, 200, {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    });
+  });
+
+  router.get("/robots.txt", (c) => {
+    const origin = new URL(c.req.url).origin;
+    // staging は BASIC 認証が有効 = 非公開環境。存在ベースで確実にクロールを止める
+    // (fail-loud / secure by default)。production は BASIC 認証を持たない。
+    const isPrivate = Boolean(c.env.BASIC_AUTH_USER);
+    const body = isPrivate
+      ? "User-agent: *\nDisallow: /\n"
+      : `User-agent: *\nAllow: /\n\nSitemap: ${origin}/sitemap.xml\n`;
+    return c.body(body, 200, {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    });
+  });
+
+  return router;
+}

--- a/app/backend/index.ts
+++ b/app/backend/index.ts
@@ -14,6 +14,7 @@ import { createRefreshRouter } from "./handlers/notes/refresh.handler";
 import { createTagsApiRouter } from "./handlers/notes/tags.handler";
 import { createOgRouter } from "./handlers/og.handler";
 import { createPagesRouter } from "./handlers/pages";
+import { createSeoRouter } from "./handlers/seo.handler";
 import { NoteNotFoundError } from "~/backend/domain/note";
 import { UserNotFoundError } from "~/backend/domain/user";
 import { requireSession } from "~/backend/middleware/auth";
@@ -64,6 +65,7 @@ app.route("/api/v1/notes", createNoteAssetsRouter());
 app.route("/api/v1/tags", createTagsApiRouter());
 app.route("/og", createOgRouter());
 app.route("/", createFeedRouter());
+app.route("/", createSeoRouter());
 
 // ノート同期 (コンテンツ正本 → D1 + R2)。POST /api/v1/refresh。
 // session ではなく REFRESH_SECRET で保護する運用エンドポイントなので、requireSession

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -48,6 +48,7 @@ function Head({ title, description, og }: HeadProps): React.JSX.Element {
         title="yantene.net"
         href="/feed.xml"
       />
+      <link rel="canonical" href={og.url} />
       <meta property="og:site_name" content="yantene.net" />
       <meta property="og:locale" content="ja_JP" />
       <meta property="og:title" content={og.title} />
@@ -91,11 +92,24 @@ export const rootView: RootView = async (page, c) => {
     type: pageOg.type ?? "website",
   };
 
+  // schema.org 構造化データ (ページが jsonLd prop を渡したときのみ)。
+  // </script> 打ち切りを防ぐため "<" をエスケープしてから埋め込む。
+  const jsonLd = page.props.jsonLd;
+  // "<" を JSON の < エスケープに置換して </script> 打ち切りを防ぐ。
+  const jsonLdBody = JSON.stringify(jsonLd).replaceAll("<", String.raw`\u003c`);
+  const jsonLdScript =
+    jsonLd === undefined
+      ? ""
+      : // eslint-disable-next-line no-secrets/no-secrets -- MIME タイプ文字列の誤検知
+        `<script type="application/ld+json">${jsonLdBody}</script>`;
+
   const { head, body } = await renderPage(page);
   const headHtml =
     renderToString(
       <Head title={meta.title} description={meta.description} og={og} />,
-    ) + head.join("");
+    ) +
+    head.join("") +
+    jsonLdScript;
 
   // body には Inertia の SSR 出力 (<script data-page="app"> + <div id="app">) が
   // すでに含まれている。ここで <div id="app"> を重ねて巻くと id が重複し、


### PR DESCRIPTION
Closes #50。/sitemap.xml (D1 から・記事 lastmod つき)・/robots.txt (staging は Disallow・prod は sitemap 案内)・記事に BlogPosting JSON-LD・canonical。staging 確認済み (sitemap 30 urls / robots Disallow / JSON-LD)。