### PR TITLE
feat: 関連記事 (タグ重複) を記事末に表示

### DIFF
--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -1,4 +1,5 @@
 import type { NoteSlug } from "./note-slug.vo";
+import type { NoteTag } from "./note-tag.vo";
 import type { Note } from "./note.entity";
 
 /** 一覧の並び替え基準。 */
@@ -34,6 +35,16 @@ export interface NoteTagCount {
 export interface INoteQueryRepository {
   findBySlug(slug: NoteSlug): Promise<Note | undefined>;
   list(query: NoteListQuery): Promise<NoteListResult>;
+  /**
+   * タグの重複数でスコアリングした関連ノートを返す。自分自身は除外し、
+   * 重複数の降順 → 公開日の降順 → slug 昇順で並べ、上限 limit 件を返す。
+   * tags が空なら空配列。
+   */
+  findRelated(
+    slug: NoteSlug,
+    tags: readonly NoteTag[],
+    limit: number,
+  ): Promise<readonly Note[]>;
   /** 全タグと各記事数を返す (タグ索引ページ用)。件数降順・タグ昇順。 */
   listTags(): Promise<readonly NoteTagCount[]>;
   /**

--- a/app/backend/handlers/notes/detail.handler.ts
+++ b/app/backend/handlers/notes/detail.handler.ts
@@ -6,9 +6,14 @@ import {
   InvalidNoteSlugError,
   NoteNotFoundError,
   NoteSlug,
+  NoteTag,
 } from "~/backend/domain/note";
+import { toPublicNote } from "~/backend/handlers/note-view";
 import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
 import { R2NoteContentCache } from "~/backend/infra/r2/r2-note-content-cache";
+
+/** 記事末に出す関連記事の最大件数。 */
+const RELATED_LIMIT = 6;
 
 /**
  * slug からノート詳細 (メタデータ + キャッシュ済み MDAST) を読む。
@@ -95,10 +100,18 @@ export function createNoteDetailPagesRouter(): Hono<{
     }
 
     const origin = new URL(c.req.url).origin;
+    const relatedTags = detail.note.tags.map((tag) => NoteTag.create(tag));
+    const query = new D1NoteQueryRepository(c.env.D1);
+    const related = await query.findRelated(
+      NoteSlug.create(detail.note.slug),
+      relatedTags,
+      RELATED_LIMIT,
+    );
     return c.render("notes/show", {
       locale: c.get("locale"),
       note: detail.note,
       mdast: detail.mdast,
+      related: related.map((note) => toPublicNote(note)),
       og: {
         title: detail.note.title,
         description: detail.note.summary,

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -201,4 +201,38 @@ describe("D1NoteQueryRepository", () => {
     );
     expect(found?.tags.map((tag) => tag.toString())).toEqual(["新しい"]);
   });
+
+  it("finds related notes ranked by tag overlap, excluding self", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    await cmd.upsert(seedTagged("target", "2026-01-01", ["x", "y"]));
+    await cmd.upsert(seedTagged("both", "2026-01-02", ["x", "y"])); // 重複 2
+    await cmd.upsert(seedTagged("one", "2026-03-01", ["x"])); // 重複 1
+    await cmd.upsert(seedTagged("none", "2026-05-01", ["z"])); // 重複 0
+
+    const related = await new D1NoteQueryRepository(d1).findRelated(
+      NoteSlug.create("target"),
+      [NoteTag.create("x"), NoteTag.create("y")],
+      6,
+    );
+
+    // 重複数の降順: both(2) → one(1)。none(0) と自分自身は除外。
+    expect(related.map((note) => note.slug.toString())).toEqual([
+      "both",
+      "one",
+    ]);
+  });
+
+  it("returns no related notes when the note has no tags", async () => {
+    const d1 = createTestD1();
+    await new D1NoteCommandRepository(d1).upsert(
+      seedTagged("solo", "2026-01-01", ["x"]),
+    );
+    const related = await new D1NoteQueryRepository(d1).findRelated(
+      NoteSlug.create("solo"),
+      [],
+      6,
+    );
+    expect(related).toEqual([]);
+  });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -1,4 +1,14 @@
-import { asc, count, desc, eq, inArray, type SQL } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  inArray,
+  ne,
+  type SQL,
+} from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { rowToNote } from "./note-row";
 import type {
@@ -73,6 +83,29 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
       notes: rows.map((row) => rowToNote(row, tagsByNote.get(row.id) ?? [])),
       total,
     };
+  }
+
+  async findRelated(
+    slug: NoteSlug,
+    tags: readonly NoteTag[],
+    limit: number,
+  ): Promise<readonly Note[]> {
+    if (tags.length === 0) return [];
+    const tagValues = tags.map((tag) => tag.toString());
+    const slugValue = slug.toString();
+    const overlap = count(noteTags.tag);
+    const rows = await this.db
+      .select({ ...getTableColumns(notes), overlap })
+      .from(notes)
+      .innerJoin(noteTags, eq(noteTags.noteId, notes.id))
+      .where(and(inArray(noteTags.tag, tagValues), ne(notes.slug, slugValue)))
+      .groupBy(notes.id)
+      // 重複数の降順 → 公開日の降順 → slug 昇順 (決定的なタイブレーカ)。
+      .orderBy(desc(overlap), desc(notes.publishedOn), asc(notes.slug))
+      .limit(limit);
+
+    const tagsByNote = await this.loadTags(rows.map((row) => row.id));
+    return rows.map((row) => rowToNote(row, tagsByNote.get(row.id) ?? []));
   }
 
   async listTags(): Promise<readonly NoteTagCount[]> {

--- a/app/frontend/pages/notes/show.tsx
+++ b/app/frontend/pages/notes/show.tsx
@@ -5,6 +5,7 @@ import type { PageProps } from "~/frontend/page-props";
 import { Footer } from "~/frontend/components/layout/footer";
 import { Header } from "~/frontend/components/layout/header";
 import { MdastRenderer } from "~/frontend/components/mdast/mdast-renderer";
+import { NoteCard } from "~/frontend/components/note-card/note-card";
 import { AppLayout } from "~/frontend/layouts/app-layout";
 
 interface NoteMeta {
@@ -20,11 +21,13 @@ interface NoteMeta {
 interface NoteShowProps extends PageProps {
   readonly note: NoteMeta | null;
   readonly mdast: MdastRoot | null;
+  readonly related?: readonly NoteMeta[];
 }
 
 export default function NoteShow({
   note,
   mdast,
+  related = [],
 }: NoteShowProps): React.JSX.Element {
   const { t } = useTranslation();
 
@@ -86,6 +89,16 @@ export default function NoteShow({
           )}
         </header>
         <MdastRenderer node={mdast} />
+        {related.length > 0 && (
+          <section className="mt-16 border-t border-base-300 pt-10">
+            <h2 className="mb-6 text-xl font-bold">{t("notes.related")}</h2>
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              {related.map((item) => (
+                <NoteCard key={item.slug} {...item} />
+              ))}
+            </div>
+          </section>
+        )}
       </main>
       <Footer />
     </AppLayout>

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -18,6 +18,7 @@
     "title": "Notes",
     "heading": "Notes",
     "empty": "No notes have been published yet.",
+    "related": "Related notes",
     "filteredByTag": "Tagged “{{tag}}”",
     "clearFilter": "Show all",
     "pagination": {

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -18,6 +18,7 @@
     "title": "ノート",
     "heading": "ノート",
     "empty": "まだ公開されたノートがない。",
+    "related": "関連記事",
     "filteredByTag": "タグ「{{tag}}」",
     "clearFilter": "すべて表示",
     "pagination": {


### PR DESCRIPTION
Closes #53。findRelated (タグ重複スコア・自分除外・上限6) を追加し記事末に NoteCard で表示。テスト追加。staging 確認済み。