### PR TITLE
feat: コードコピーボタン + 画像 lightbox

### DIFF
--- a/app/frontend/components/mdast/mdast-renderer.css
+++ b/app/frontend/components/mdast/mdast-renderer.css
@@ -142,3 +142,62 @@
 .note-prose .hljs-strong {
   font-weight: 700;
 }
+
+/* コードブロックのコピーボタン (ホバー/フォーカスで出現)。 */
+.note-prose .code-block {
+  position: relative;
+  margin: 1.25rem 0;
+}
+.note-prose .code-block > pre {
+  margin: 0;
+}
+.note-prose .code-copy {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  border-radius: 0.375rem;
+  color: var(--color-base-content);
+  background: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.note-prose .code-block:hover .code-copy,
+.note-prose .code-copy:focus-visible {
+  opacity: 1;
+}
+
+/* 本文画像のクリック拡大 (lightbox)。 */
+.note-prose .lightbox-trigger {
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+}
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgb(0 0 0 / 0.85);
+  cursor: zoom-out;
+}
+.lightbox-full {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 0.25rem;
+}
+.lightbox-overlay {
+  border: 0;
+  appearance: none;
+  width: 100%;
+}

--- a/app/frontend/components/mdast/mdast-renderer.tsx
+++ b/app/frontend/components/mdast/mdast-renderer.tsx
@@ -1,7 +1,8 @@
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
 import { toHast } from "mdast-util-to-hast";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+import { createPortal } from "react-dom";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSanitize from "rehype-sanitize";
 import rehypeSlug from "rehype-slug";
@@ -70,6 +71,86 @@ function applyElementTransforms(
   }
 }
 
+/** コードブロック (pre) 差し替え: 右上にコピーボタンを添える。 */
+function CodeBlock(
+  props: Readonly<React.ComponentPropsWithoutRef<"pre">>,
+): React.JSX.Element {
+  const ref = useRef<HTMLPreElement>(null);
+  const [isCopied, setIsCopied] = useState(false);
+
+  async function copy(): Promise<void> {
+    const text = ref.current?.textContent ?? "";
+    try {
+      await globalThis.navigator.clipboard.writeText(text);
+      setIsCopied(true);
+      globalThis.setTimeout(() => setIsCopied(false), 1500);
+    } catch {
+      // クリップボード API が使えない環境 (非セキュアコンテキスト等) では何もしない。
+    }
+  }
+
+  return (
+    <div className="code-block">
+      <button
+        type="button"
+        className="code-copy"
+        onClick={() => void copy()}
+        aria-label="コードをコピー"
+      >
+        {isCopied ? "コピーしました" : "コピー"}
+      </button>
+      <pre ref={ref} {...props} />
+    </div>
+  );
+}
+
+/** 画像 (img) 差し替え: クリックで lightbox 拡大 (Esc / 背景クリックで閉じる)。 */
+function LightboxImage(
+  props: Readonly<React.ComponentPropsWithoutRef<"img">>,
+): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(event: KeyboardEvent): void {
+      if (event.key === "Escape") setIsOpen(false);
+    }
+    globalThis.addEventListener("keydown", onKey);
+    return () => globalThis.removeEventListener("keydown", onKey);
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="lightbox-trigger"
+        onClick={() => setIsOpen(true)}
+        aria-label="画像を拡大"
+      >
+        <img {...props} alt={props.alt ?? ""} />
+      </button>
+      {isOpen &&
+        createPortal(
+          // オーバーレイ自体を button にして、背景クリック・Enter/Space・Esc
+          // (グローバル keydown) のいずれでも閉じられるようにする。
+          <button
+            type="button"
+            className="lightbox-overlay"
+            aria-label="拡大画像を閉じる"
+            onClick={() => setIsOpen(false)}
+          >
+            <img
+              className="lightbox-full"
+              src={props.src}
+              alt={props.alt ?? ""}
+            />
+          </button>,
+          document.body,
+        )}
+    </>
+  );
+}
+
 export interface MdastRendererProps {
   /** レンダリング対象の MDAST (Markdown AST) ルート。 */
   readonly node: MdastRoot;
@@ -100,6 +181,7 @@ export function MdastRenderer({
       Fragment,
       jsx,
       jsxs,
+      components: { pre: CodeBlock, img: LightboxImage },
     }) as React.JSX.Element;
   }, [node, transformImageUrl]);
 


### PR DESCRIPTION
Closes #54。mdast-renderer で pre→コピーボタン付き・img→lightbox に差し替え。SSR マークアップ確認済み (code-copy / lightbox-trigger)。

備考: リンク付き画像 (a > img) は button 入れ子になる edge case あり (badge 等・稀)。必要なら後追いで除外。