### PR TITLE
feat: 記事内 目次 (ToC) — 右 sticky・現在地フォーカス・h3 折り畳み

### DIFF
--- a/app/backend/handlers/notes/detail.handler.ts
+++ b/app/backend/handlers/notes/detail.handler.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { toNoteDetail } from "./note-detail-view";
+import { extractHeadings } from "./toc-headings";
 import type { NoteDetail } from "./note-detail-view";
+import type { Root } from "mdast";
 import type { LocaleVariables } from "~/backend/middleware/locale";
 import {
   InvalidNoteSlugError,
@@ -112,6 +114,7 @@ export function createNoteDetailPagesRouter(): Hono<{
       note: detail.note,
       mdast: detail.mdast,
       related: related.map((note) => toPublicNote(note)),
+      headings: extractHeadings(detail.mdast as Root),
       og: {
         title: detail.note.title,
         description: detail.note.summary,

--- a/app/backend/handlers/notes/toc-headings.ts
+++ b/app/backend/handlers/notes/toc-headings.ts
@@ -1,0 +1,31 @@
+import GithubSlugger from "github-slugger";
+import { toString as mdastToString } from "mdast-util-to-string";
+import type { Root } from "mdast";
+
+/** 目次の 1 見出し。id はレンダリング側 (rehype-slug) の見出し id と一致する。 */
+export interface TocHeading {
+  readonly id: string;
+  readonly text: string;
+  readonly level: 2 | 3;
+}
+
+/**
+ * MDAST から目次用の見出し (h2/h3) を document 順に抽出する。
+ *
+ * id は rehype-slug と同じ github-slugger で採番するため、MdastRenderer が付ける
+ * 見出し id と一致する。重複採番のカウンタを rehype-slug と揃えるため、目次に
+ * 出さない depth の見出しでも slugger は進める。
+ */
+export function extractHeadings(root: Root): readonly TocHeading[] {
+  const slugger = new GithubSlugger();
+  const headings: TocHeading[] = [];
+  for (const node of root.children) {
+    if (node.type !== "heading") continue;
+    const text = mdastToString(node).trim();
+    const id = slugger.slug(text);
+    if ((node.depth === 2 || node.depth === 3) && text.length > 0) {
+      headings.push({ id, text, level: node.depth });
+    }
+  }
+  return headings;
+}

--- a/app/frontend/components/toc/table-of-contents.stories.tsx
+++ b/app/frontend/components/toc/table-of-contents.stories.tsx
@@ -1,0 +1,22 @@
+import { TableOfContents, type TocHeading } from "./table-of-contents";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const headings: TocHeading[] = [
+  { id: "intro", text: "はじめに", level: 2 },
+  { id: "setup", text: "セットアップ", level: 2 },
+  { id: "install", text: "インストール", level: 3 },
+  { id: "config", text: "設定", level: 3 },
+  { id: "usage", text: "使い方", level: 2 },
+];
+
+const meta: Meta<typeof TableOfContents> = {
+  title: "TableOfContents/TableOfContents",
+  component: TableOfContents,
+  parameters: { layout: "padded" },
+  args: { title: "目次", headings },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/frontend/components/toc/table-of-contents.tsx
+++ b/app/frontend/components/toc/table-of-contents.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+
+export interface TocHeading {
+  readonly id: string;
+  readonly text: string;
+  readonly level: 2 | 3;
+}
+
+interface Section {
+  readonly heading: TocHeading;
+  readonly children: readonly TocHeading[];
+}
+
+/** これ未満の見出し数なら目次を出さない。 */
+const MIN_HEADINGS = 2;
+
+/** フラットな見出し列を h2 セクション (+ 配下 h3) にまとめる。 */
+function toSections(headings: readonly TocHeading[]): readonly Section[] {
+  const sections: { heading: TocHeading; children: TocHeading[] }[] = [];
+  for (const heading of headings) {
+    const last = sections.at(-1);
+    // h3 は直前のセクション配下に。h2 (または先頭の h3) は新しいセクションを開く。
+    if (heading.level === 3 && last !== undefined) {
+      last.children.push(heading);
+    } else {
+      sections.push({ heading, children: [] });
+    }
+  }
+  return sections;
+}
+
+/**
+ * scroll-spy: 本文の見出し要素を IntersectionObserver で監視し、ビューポート上部に
+ * 到達している最初の見出しを active にする。何も交差していないときは直前の値を保つ。
+ */
+function useActiveHeading(headings: readonly TocHeading[]): string {
+  const [activeId, setActiveId] = useState("");
+  useEffect(() => {
+    if (headings.length === 0) return;
+    const elements = [
+      ...document.querySelectorAll<HTMLElement>(
+        ".note-prose h2, .note-prose h3",
+      ),
+    ].filter((element) => element.id.length > 0);
+    if (elements.length === 0) return;
+
+    const visibility = new Map<string, boolean>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          visibility.set(entry.target.id, entry.isIntersecting);
+        }
+        const firstVisible = headings.find(
+          (heading) => visibility.get(heading.id) === true,
+        );
+        if (firstVisible !== undefined) setActiveId(firstVisible.id);
+      },
+      // ビューポート上部 20% のバンドに入った見出しを「現在地」とみなす。
+      { rootMargin: "0px 0px -80% 0px" },
+    );
+    for (const element of elements) observer.observe(element);
+    return () => observer.disconnect();
+  }, [headings]);
+  return activeId;
+}
+
+interface TableOfContentsProps {
+  /** 見出しラベル ("目次" 等・i18n で外から渡す)。 */
+  readonly title: string;
+  /** サーバー側で抽出した見出し (rehype-slug と一致する id 付き)。 */
+  readonly headings: readonly TocHeading[];
+}
+
+/**
+ * 記事内の目次。右カラムに sticky で置く前提。scroll-spy で現在位置を強調し、
+ * h3 はアクティブな h2 セクション配下のみ展開する。見出しが少なければ描画しない。
+ */
+export function TableOfContents({
+  title,
+  headings,
+}: TableOfContentsProps): React.JSX.Element | null {
+  const activeId = useActiveHeading(headings);
+
+  if (headings.length < MIN_HEADINGS) return null;
+
+  const sections = toSections(headings);
+  return (
+    <nav aria-label={title} className="text-sm">
+      <p className="mb-3 font-bold text-base-content/70">{title}</p>
+      <ul className="border-l border-base-300">
+        {sections.map((section) => {
+          const isActiveSection =
+            section.heading.id === activeId ||
+            section.children.some((child) => child.id === activeId);
+          return (
+            <li key={section.heading.id}>
+              <a
+                href={`#${section.heading.id}`}
+                className={`-ml-px block border-l-2 py-1 pl-4 transition-colors ${
+                  section.heading.id === activeId
+                    ? "border-primary font-medium text-primary"
+                    : "border-transparent text-base-content/60 hover:text-base-content"
+                }`}
+              >
+                {section.heading.text}
+              </a>
+              {isActiveSection && section.children.length > 0 && (
+                <ul>
+                  {section.children.map((child) => (
+                    <li key={child.id}>
+                      <a
+                        href={`#${child.id}`}
+                        className={`-ml-px block border-l-2 py-0.5 pl-8 text-xs transition-colors ${
+                          child.id === activeId
+                            ? "border-primary font-medium text-primary"
+                            : "border-transparent text-base-content/50 hover:text-base-content"
+                        }`}
+                      >
+                        {child.text}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/app/frontend/pages/notes/show.tsx
+++ b/app/frontend/pages/notes/show.tsx
@@ -6,6 +6,10 @@ import { Footer } from "~/frontend/components/layout/footer";
 import { Header } from "~/frontend/components/layout/header";
 import { MdastRenderer } from "~/frontend/components/mdast/mdast-renderer";
 import { NoteCard } from "~/frontend/components/note-card/note-card";
+import {
+  TableOfContents,
+  type TocHeading,
+} from "~/frontend/components/toc/table-of-contents";
 import { AppLayout } from "~/frontend/layouts/app-layout";
 
 interface NoteMeta {
@@ -22,12 +26,14 @@ interface NoteShowProps extends PageProps {
   readonly note: NoteMeta | null;
   readonly mdast: MdastRoot | null;
   readonly related?: readonly NoteMeta[];
+  readonly headings?: readonly TocHeading[];
 }
 
 export default function NoteShow({
   note,
   mdast,
   related = [],
+  headings = [],
 }: NoteShowProps): React.JSX.Element {
   const { t } = useTranslation();
 
@@ -56,50 +62,57 @@ export default function NoteShow({
         <meta name="description" content={note.summary} />
       </Head>
       <Header />
-      <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-10">
-        <header className="mb-8">
-          <h1 className="text-4xl font-bold">{note.title}</h1>
-          <time
-            dateTime={note.publishedOn}
-            className="mt-2 block text-sm text-base-content/60"
-          >
-            {note.publishedOn}
-          </time>
-          {note.tags.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {note.tags.map((tg) => (
-                <Link
-                  key={tg}
-                  href={`/notes?tag=${encodeURIComponent(tg)}`}
-                  className="badge badge-outline gap-1 hover:badge-primary"
-                >
-                  {tg}
-                </Link>
-              ))}
-            </div>
+      <div className="mx-auto flex w-full max-w-6xl flex-1 gap-10 px-6 py-10">
+        <main className="min-w-0 max-w-3xl flex-1">
+          <header className="mb-8">
+            <h1 className="text-4xl font-bold">{note.title}</h1>
+            <time
+              dateTime={note.publishedOn}
+              className="mt-2 block text-sm text-base-content/60"
+            >
+              {note.publishedOn}
+            </time>
+            {note.tags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {note.tags.map((tg) => (
+                  <Link
+                    key={tg}
+                    href={`/notes?tag=${encodeURIComponent(tg)}`}
+                    className="badge badge-outline gap-1 hover:badge-primary"
+                  >
+                    {tg}
+                  </Link>
+                ))}
+              </div>
+            )}
+            {note.imageUrl !== null && (
+              <img
+                src={note.imageUrl}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="mt-6 w-full rounded-lg object-cover"
+              />
+            )}
+          </header>
+          <MdastRenderer node={mdast} />
+          {related.length > 0 && (
+            <section className="mt-16 border-t border-base-300 pt-10">
+              <h2 className="mb-6 text-xl font-bold">{t("notes.related")}</h2>
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                {related.map((item) => (
+                  <NoteCard key={item.slug} {...item} />
+                ))}
+              </div>
+            </section>
           )}
-          {note.imageUrl !== null && (
-            <img
-              src={note.imageUrl}
-              alt=""
-              loading="lazy"
-              decoding="async"
-              className="mt-6 w-full rounded-lg object-cover"
-            />
-          )}
-        </header>
-        <MdastRenderer node={mdast} />
-        {related.length > 0 && (
-          <section className="mt-16 border-t border-base-300 pt-10">
-            <h2 className="mb-6 text-xl font-bold">{t("notes.related")}</h2>
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-              {related.map((item) => (
-                <NoteCard key={item.slug} {...item} />
-              ))}
-            </div>
-          </section>
-        )}
-      </main>
+        </main>
+        <aside className="hidden w-60 shrink-0 lg:block">
+          <div className="sticky top-24">
+            <TableOfContents title={t("notes.toc")} headings={headings} />
+          </div>
+        </aside>
+      </div>
       <Footer />
     </AppLayout>
   );

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -19,6 +19,7 @@
     "heading": "Notes",
     "empty": "No notes have been published yet.",
     "related": "Related notes",
+    "toc": "Contents",
     "filteredByTag": "Tagged “{{tag}}”",
     "clearFilter": "Show all",
     "pagination": {

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -19,6 +19,7 @@
     "heading": "ノート",
     "empty": "まだ公開されたノートがない。",
     "related": "関連記事",
+    "toc": "目次",
     "filteredByTag": "タグ「{{tag}}」",
     "clearFilter": "すべて表示",
     "pagination": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@js-temporal/polyfill": "^0.5.1",
     "daisyui": "^5.6.13",
     "drizzle-orm": "^0.45.2",
+    "github-slugger": "^2.0.0",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "hono": "^4.12.27",
     "i18next": "^26.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6


### PR DESCRIPTION
Closes #52。サーバー側で見出し抽出 (github-slugger→rehype-slug と id 一致)、右カラム sticky・IntersectionObserver で scroll-spy・h3 はアクティブ節のみ展開。staging で id 一致・SSR 描画確認済み (sticky/scroll-spy はブラウザツール不通のため目視未実施)。