### PR TITLE
test: 全ページ描画の回帰防止 (rootView テスト + スモーク)

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -68,3 +68,19 @@ pnpm run check   # lint + format + typecheck をまとめて検証
 
 加えて、変更差分に対して `/code-review` を実行し、critical な指摘があれば修正してから
 commit / push する。
+
+## 全ページ共通の描画経路を触ったときのスモーク
+
+`app/frontend/root-view.tsx` / `layouts/` / `middleware/` / `entry.server.tsx` など
+**全ページが通る共有経路**を変更したら、その機能のページだけでなく**各ページ種別を必ず確認する**。
+過去、`root-view` の JSON-LD 実装が jsonLd を持たないページ (トップ/一覧/タグ/ログイン) を
+すべて 500 にした回帰があり、記事ページだけ確認していて見逃した。
+
+- **自動 (CI)**: `root-view.test.tsx` / `json-ld.test.ts` が jsonLd 有無の両パスを検証する。
+  共有描画経路を変えたら同種のテストを足す。
+- **手動 (デプロイ後)**: staging へ deploy したら主要 URL のスモークを走らせる。
+
+```bash
+SMOKE_BASE=https://yantene-staging.yantene.workers.dev \
+  SMOKE_USER=<basic-user> SMOKE_PASS=<basic-pass> pnpm run smoke
+```

--- a/app/frontend/root-view.test.tsx
+++ b/app/frontend/root-view.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+// 本物の Inertia SSR は vitest では回らないため renderPage をスタブし、
+// rootView 自体のロジック (jsonLd / og / HTML 組み立て) を検証する。
+vi.mock("~/frontend/entry.server", () => ({
+  renderPage: () =>
+    Promise.resolve({
+      head: ["<title>t</title>"],
+      body: '<div id="app"></div>',
+    }),
+}));
+
+const { rootView } = await import("./root-view");
+
+function context(
+  url = "http://localhost/notes",
+): Parameters<typeof rootView>[1] {
+  return { req: { url } } as unknown as Parameters<typeof rootView>[1];
+}
+
+describe("rootView", () => {
+  it("renders a page WITHOUT jsonLd without throwing (500 回帰の防止)", async () => {
+    const page = { props: { locale: "ja" } };
+    const html = await rootView(page as never, context());
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).not.toContain("application/ld+json");
+  });
+
+  it("emits a ld+json script when a page provides jsonLd", async () => {
+    const page = {
+      props: { locale: "ja", jsonLd: { "@type": "BlogPosting" } },
+    };
+    const html = await rootView(page as never, context());
+    expect(html).toContain("application/ld+json");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check": "pnpm run lint && pnpm run format && pnpm run typecheck",
     "test": "vitest",
     "test:run": "vitest run",
+    "smoke": "node scripts/smoke.mjs",
     "storybook:dev": "storybook dev -p 6006 --host 0.0.0.0",
     "storybook:build": "storybook build",
     "db:generate": "drizzle-kit generate",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * デプロイ後スモーク。主要な公開 URL を叩き、5xx (サーバーエラー) が無いかを確認する。
+ * rootView / layout / middleware / entry.server 等、全ページ共通の描画経路や env / binding
+ * 起因の実行時回帰を、単体テストが見られない実環境で検知するための最終確認。
+ *
+ * 使い方:
+ *   SMOKE_BASE=https://yantene-staging.yantene.workers.dev \
+ *   SMOKE_USER=<user> SMOKE_PASS=<pass> pnpm run smoke
+ *
+ * BASIC 認証が無い環境 (production) では SMOKE_USER / SMOKE_PASS を省略する。
+ */
+import { Buffer } from "node:buffer";
+
+const base = process.env.SMOKE_BASE ?? process.argv[2];
+if (base === undefined || base.length === 0) {
+  console.error("usage: SMOKE_BASE=<url> node scripts/smoke.mjs");
+  process.exit(2);
+}
+
+const user = process.env.SMOKE_USER;
+const pass = process.env.SMOKE_PASS;
+let authHeader = {};
+if (user !== undefined && pass !== undefined) {
+  // eslint-disable-next-line unicorn/prefer-uint8array-base64 -- Uint8Array#toBase64 は Node 24.18 に未実装。
+  const encoded = Buffer.from(`${user}:${pass}`).toString("base64");
+  authHeader = { Authorization: `Basic ${encoded}` };
+}
+
+/** 各ページ種別を 1 つずつ + 主要な公開エンドポイント。 */
+const paths = [
+  "/",
+  "/notes",
+  "/tags",
+  "/login",
+  "/search",
+  "/search?q=test",
+  "/notes/does-not-exist",
+  "/feed.xml",
+  "/sitemap.xml",
+  "/robots.txt",
+  "/og/default",
+];
+
+let failed = 0;
+for (const path of paths) {
+  let status = 0;
+  try {
+    const res = await fetch(`${base}${path}`, {
+      headers: authHeader,
+      redirect: "manual",
+    });
+    status = res.status;
+  } catch (error) {
+    console.log(`x ERR ${path} (${error.message})`);
+    failed += 1;
+    continue;
+  }
+  const isOk = status < 500;
+  if (!isOk) failed += 1;
+  console.log(`${isOk ? "ok" : "x "} ${status} ${path}`);
+}
+
+if (failed > 0) {
+  console.error(`\nx ${failed} path(s) returned a server error (>= 500)`);
+  process.exit(1);
+}
+console.log(`\nok all ${paths.length} paths responded < 500`);


### PR DESCRIPTION
Closes #65。#50 回帰 (jsonLd 無しページ全 500) の再発防止。rootView 描画テスト (CI)・デプロイ後スモークスクリプト (pnpm run smoke)・規約明文化。