### PR TITLE
feat: 連載 (シリーズ)

### DIFF
--- a/app/backend/domain/note/index.ts
+++ b/app/backend/domain/note/index.ts
@@ -4,7 +4,7 @@ export { InvalidNoteSlugError, NoteSlug } from "./note-slug.vo";
 export { InvalidNoteTagError, NoteTag } from "./note-tag.vo";
 export { InvalidNoteTitleError, NoteTitle } from "./note-title.vo";
 export { Note } from "./note.entity";
-export type { NoteId } from "./note.entity";
+export type { NoteId, NoteSeries } from "./note.entity";
 export type {
   CachedAsset,
   INoteContentCache,

--- a/app/backend/domain/note/note.entity.test.ts
+++ b/app/backend/domain/note/note.entity.test.ts
@@ -64,6 +64,7 @@ describe("Note.reconstruct", () => {
       tags: [],
       publishedOn,
       lastModifiedOn,
+      series: undefined,
       sourceHash: "h",
       createdAt,
       updatedAt,

--- a/app/backend/domain/note/note.entity.ts
+++ b/app/backend/domain/note/note.entity.ts
@@ -11,6 +11,16 @@ import type {
 
 export type NoteId = EntityId<"Note">;
 
+/** 連載 (シリーズ) 情報。フロントマター由来。単発記事は持たない。 */
+export interface NoteSeries {
+  /** 表示名 (frontmatter series)。 */
+  readonly name: string;
+  /** URL 用の slug (表示名を slug 化したもの)。 */
+  readonly slug: string;
+  /** 連載内の並び順 (frontmatter seriesOrder)。 */
+  readonly order: number;
+}
+
 interface NoteFields<T extends IPersisted | IUnpersisted> {
   readonly id: T["id"] extends string ? NoteId : undefined;
   readonly slug: NoteSlug;
@@ -25,6 +35,8 @@ interface NoteFields<T extends IPersisted | IUnpersisted> {
   readonly publishedOn: Temporal.PlainDate;
   /** フロントマター由来の最終更新日 (日付のみ)。 */
   readonly lastModifiedOn: Temporal.PlainDate;
+  /** 連載 (シリーズ) 情報。単発記事は undefined。 */
+  readonly series: NoteSeries | undefined;
   /**
    * コンテンツ正本 (Markdown) のリビジョン識別子。refresh 時の変更検出に使う
    * (Artifacts のツリーが返すファイルハッシュ)。
@@ -51,6 +63,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     tags?: readonly NoteTag[];
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
+    series?: NoteSeries;
     sourceHash: string;
   }): Note<IUnpersisted> {
     return new Note({
@@ -62,6 +75,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
       tags: params.tags ?? [],
       publishedOn: params.publishedOn,
       lastModifiedOn: params.lastModifiedOn,
+      series: params.series,
       sourceHash: params.sourceHash,
       createdAt: undefined,
       updatedAt: undefined,
@@ -77,6 +91,7 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
     tags: readonly NoteTag[];
     publishedOn: Temporal.PlainDate;
     lastModifiedOn: Temporal.PlainDate;
+    series: NoteSeries | undefined;
     sourceHash: string;
     createdAt: Temporal.Instant;
     updatedAt: Temporal.Instant;
@@ -114,6 +129,10 @@ export class Note<T extends IPersisted | IUnpersisted = IPersisted> {
 
   get lastModifiedOn(): Temporal.PlainDate {
     return this.fields.lastModifiedOn;
+  }
+
+  get series(): NoteSeries | undefined {
+    return this.fields.series;
   }
 
   get sourceHash(): string {

--- a/app/backend/domain/note/note.query-repository.interface.ts
+++ b/app/backend/domain/note/note.query-repository.interface.ts
@@ -52,6 +52,8 @@ export interface INoteQueryRepository {
   ): Promise<readonly Note[]>;
   /** 全タグと各記事数を返す (タグ索引ページ用)。件数降順・タグ昇順。 */
   listTags(): Promise<readonly NoteTagCount[]>;
+  /** 連載 (シリーズ) の記事を seriesOrder 昇順で返す。該当なしなら空配列。 */
+  listBySeries(seriesSlug: string): Promise<readonly Note[]>;
   /**
    * 全ノートの slug → sourceHash の対応を返す。refresh の変更検出に使う
    * (Artifacts のツリーが返すハッシュと突き合わせる)。

--- a/app/backend/handlers/note-view.ts
+++ b/app/backend/handlers/note-view.ts
@@ -18,6 +18,12 @@ export interface PublicNote {
   readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
+  /** 連載 (シリーズ) 情報。単発記事は null。 */
+  readonly series: {
+    readonly name: string;
+    readonly slug: string;
+    readonly order: number;
+  } | null;
 }
 
 export interface Pagination {
@@ -42,6 +48,7 @@ export function toPublicNote(note: Note): PublicNote {
     tags: note.tags.map((tag) => tag.toJSON()),
     publishedOn: note.publishedOn.toString({ calendarName: "never" }),
     lastModifiedOn: note.lastModifiedOn.toString({ calendarName: "never" }),
+    series: note.series ?? null,
   };
 }
 

--- a/app/backend/handlers/notes/detail.handler.ts
+++ b/app/backend/handlers/notes/detail.handler.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { toNoteDetail } from "./note-detail-view";
 import { extractHeadings } from "./toc-headings";
-import type { NoteDetail } from "./note-detail-view";
+import type { NoteDetail, PublicNoteMeta } from "./note-detail-view";
 import type { Root } from "mdast";
 import type { LocaleVariables } from "~/backend/middleware/locale";
 import {
@@ -10,12 +10,41 @@ import {
   NoteSlug,
   NoteTag,
 } from "~/backend/domain/note";
-import { toPublicNote } from "~/backend/handlers/note-view";
+import { toPublicNote, type PublicNote } from "~/backend/handlers/note-view";
 import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
 import { R2NoteContentCache } from "~/backend/infra/r2/r2-note-content-cache";
 
 /** 記事末に出す関連記事の最大件数。 */
 const RELATED_LIMIT = 6;
+
+/** 連載記事のシリーズ内ナビ (前後 + 位置)。単発記事は null。 */
+async function buildSeriesNav(
+  query: D1NoteQueryRepository,
+  note: PublicNoteMeta,
+): Promise<{
+  name: string;
+  slug: string;
+  total: number;
+  position: number;
+  prev: PublicNote | null;
+  next: PublicNote | null;
+} | null> {
+  if (note.series === null) return null;
+  const found = await query.listBySeries(note.series.slug);
+  const seriesNotes = found.map((item) => toPublicNote(item));
+  const index = seriesNotes.findIndex((item) => item.slug === note.slug);
+  return {
+    name: note.series.name,
+    slug: note.series.slug,
+    total: seriesNotes.length,
+    position: index + 1,
+    prev: index > 0 ? seriesNotes[index - 1] : null,
+    next:
+      index !== -1 && index < seriesNotes.length - 1
+        ? seriesNotes[index + 1]
+        : null,
+  };
+}
 
 /**
  * slug からノート詳細 (メタデータ + キャッシュ済み MDAST) を読む。
@@ -109,12 +138,14 @@ export function createNoteDetailPagesRouter(): Hono<{
       relatedTags,
       RELATED_LIMIT,
     );
+    const series = await buildSeriesNav(query, detail.note);
     return c.render("notes/show", {
       locale: c.get("locale"),
       note: detail.note,
       mdast: detail.mdast,
       related: related.map((note) => toPublicNote(note)),
       headings: extractHeadings(detail.mdast as Root),
+      series,
       og: {
         title: detail.note.title,
         description: detail.note.summary,

--- a/app/backend/handlers/notes/list-api.handler.test.ts
+++ b/app/backend/handlers/notes/list-api.handler.test.ts
@@ -103,6 +103,7 @@ describe("createNotesApiRouter GET /", () => {
       "imageUrl",
       "lastModifiedOn",
       "publishedOn",
+      "series",
       "slug",
       "summary",
       "tags",

--- a/app/backend/handlers/notes/note-detail-view.ts
+++ b/app/backend/handlers/notes/note-detail-view.ts
@@ -9,6 +9,11 @@ export interface PublicNoteMeta {
   readonly tags: readonly string[];
   readonly publishedOn: string;
   readonly lastModifiedOn: string;
+  readonly series: {
+    readonly name: string;
+    readonly slug: string;
+    readonly order: number;
+  } | null;
 }
 
 /** 詳細レスポンス / ページ props。メタデータ + パース済み MDAST。 */
@@ -27,6 +32,7 @@ export function toNoteDetail(note: Note, mdast: unknown): NoteDetail {
       tags: note.tags.map((tag) => tag.toJSON()),
       publishedOn: note.publishedOn.toString({ calendarName: "never" }),
       lastModifiedOn: note.lastModifiedOn.toString({ calendarName: "never" }),
+      series: note.series ?? null,
     },
     mdast,
   };

--- a/app/backend/handlers/notes/series.handler.ts
+++ b/app/backend/handlers/notes/series.handler.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+import type { LocaleVariables } from "~/backend/middleware/locale";
+import { toPublicNote } from "~/backend/handlers/note-view";
+import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
+
+/**
+ * 連載 (シリーズ) 索引の公開ページルータ (Inertia)。認証不要。
+ * GET /series/:slug → そのシリーズの記事を seriesOrder 昇順で一覧。
+ * 該当が無ければ 404 ステータスで not-found 状態を描画する。
+ */
+export function createSeriesPagesRouter(): Hono<{
+  Bindings: Env;
+  Variables: LocaleVariables;
+}> {
+  const router = new Hono<{ Bindings: Env; Variables: LocaleVariables }>();
+
+  router.get("/series/:slug", async (c) => {
+    const slug = c.req.param("slug");
+    const found = await new D1NoteQueryRepository(c.env.D1).listBySeries(slug);
+    const notes = found.map((note) => toPublicNote(note));
+
+    if (notes.length === 0) {
+      c.status(404);
+      return c.render("series/show", {
+        locale: c.get("locale"),
+        name: null,
+        notes: [],
+      });
+    }
+
+    return c.render("series/show", {
+      locale: c.get("locale"),
+      name: notes[0].series?.name ?? slug,
+      notes,
+      og: { image: "/og/default", type: "website" },
+    });
+  });
+
+  return router;
+}

--- a/app/backend/handlers/pages.ts
+++ b/app/backend/handlers/pages.ts
@@ -6,6 +6,7 @@ import { toPublicNote } from "~/backend/handlers/note-view";
 import { createNoteDetailPagesRouter } from "~/backend/handlers/notes/detail.handler";
 import { createNotesPagesRouter } from "~/backend/handlers/notes/pages.handler";
 import { createSearchPagesRouter } from "~/backend/handlers/notes/search.handler";
+import { createSeriesPagesRouter } from "~/backend/handlers/notes/series.handler";
 import { createTagsPagesRouter } from "~/backend/handlers/notes/tags.handler";
 import { D1NoteQueryRepository } from "~/backend/infra/d1/repositories";
 import {
@@ -59,6 +60,7 @@ export function createPagesRouter(): Hono<PagesBindings> {
   router.route("/", createNoteDetailPagesRouter());
   router.route("/", createTagsPagesRouter());
   router.route("/", createSearchPagesRouter());
+  router.route("/", createSeriesPagesRouter());
 
   // 認証必須ページは現状なし。将来 (有料記事等) を追加する際は、ここで
   // requireSessionOrRedirect を挟んでからマウントする。

--- a/app/backend/infra/d1/repositories/note-row.ts
+++ b/app/backend/infra/d1/repositories/note-row.ts
@@ -24,6 +24,10 @@ export function rowToNote(
     tags,
     publishedOn: isoToPlainDate(row.publishedOn),
     lastModifiedOn: isoToPlainDate(row.lastModifiedOn),
+    series:
+      row.series === null || row.seriesSlug === null || row.seriesOrder === null
+        ? undefined
+        : { name: row.series, slug: row.seriesSlug, order: row.seriesOrder },
     sourceHash: row.sourceHash,
     createdAt: unixToInstant(row.createdAt),
     updatedAt: unixToInstant(row.updatedAt),

--- a/app/backend/infra/d1/repositories/note.command-repository.ts
+++ b/app/backend/infra/d1/repositories/note.command-repository.ts
@@ -33,6 +33,9 @@ export class D1NoteCommandRepository implements INoteCommandRepository {
       imageUrl: note.imageUrl?.toString() ?? null,
       publishedOn: plainDateToIso(note.publishedOn),
       lastModifiedOn: plainDateToIso(note.lastModifiedOn),
+      series: note.series?.name ?? null,
+      seriesSlug: note.series?.slug ?? null,
+      seriesOrder: note.series?.order ?? null,
       sourceHash: note.sourceHash,
       updatedAt: nowUnix,
     };

--- a/app/backend/infra/d1/repositories/note.query-repository.test.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.test.ts
@@ -278,4 +278,28 @@ describe("D1NoteQueryRepository", () => {
     const results = await new D1NoteQueryRepository(d1).search("なんでも", 10);
     expect(results).toEqual([]);
   });
+
+  it("lists a series ordered by seriesOrder", async () => {
+    const d1 = createTestD1();
+    const cmd = new D1NoteCommandRepository(d1);
+    const part = (slug: string, order: number): Note<IUnpersisted> =>
+      Note.create({
+        slug: NoteSlug.create(slug),
+        title: NoteTitle.create(slug),
+        summary: "s",
+        publishedOn: Temporal.PlainDate.from("2026-01-01"),
+        lastModifiedOn: Temporal.PlainDate.from("2026-01-01"),
+        series: { name: "My Series", slug: "my-series", order },
+        sourceHash: `h-${slug}`,
+      });
+    await cmd.upsert(part("second", 2));
+    await cmd.upsert(part("first", 1));
+
+    const list = await new D1NoteQueryRepository(d1).listBySeries("my-series");
+    expect(list.map((note) => note.slug.toString())).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(list[0].series?.name).toBe("My Series");
+  });
 });

--- a/app/backend/infra/d1/repositories/note.query-repository.ts
+++ b/app/backend/infra/d1/repositories/note.query-repository.ts
@@ -157,6 +157,16 @@ export class D1NoteQueryRepository implements INoteQueryRepository {
       .filter((note): note is Note => note !== undefined);
   }
 
+  async listBySeries(seriesSlug: string): Promise<readonly Note[]> {
+    const rows = await this.db
+      .select()
+      .from(notes)
+      .where(eq(notes.seriesSlug, seriesSlug))
+      .orderBy(asc(notes.seriesOrder), asc(notes.slug));
+    const tagsByNote = await this.loadTags(rows.map((row) => row.id));
+    return rows.map((row) => rowToNote(row, tagsByNote.get(row.id) ?? []));
+  }
+
   async listTags(): Promise<readonly NoteTagCount[]> {
     const rows = await this.db
       .select({ tag: noteTags.tag, value: count() })

--- a/app/backend/infra/d1/schema/notes.ts
+++ b/app/backend/infra/d1/schema/notes.ts
@@ -15,6 +15,11 @@ export const notes = sqliteTable("notes", {
   title: text("title").notNull(),
   summary: text("summary").notNull(),
   imageUrl: text("image_url"),
+  // 連載 (シリーズ)。フロントマター由来。単発記事では null。
+  // series: 表示名 / series_slug: URL 用 (表示名を slug 化) / series_order: 連載内の順序。
+  series: text("series"),
+  seriesSlug: text("series_slug"),
+  seriesOrder: integer("series_order"),
   publishedOn: text("published_on").notNull(),
   lastModifiedOn: text("last_modified_on").notNull(),
   // コンテンツ正本のリビジョン識別子 (Markdown + アセットの合成ハッシュ)。

--- a/app/backend/services/note-content-parser.ts
+++ b/app/backend/services/note-content-parser.ts
@@ -17,6 +17,10 @@ export interface NoteFrontmatter {
   readonly tags: readonly string[];
   readonly publishedOn: string | undefined;
   readonly lastModifiedOn: string | undefined;
+  /** 連載名 (表示名)。単発記事では undefined。 */
+  readonly series: string | undefined;
+  /** 連載内の並び順。series があるときのみ意味を持つ。 */
+  readonly seriesOrder: number | undefined;
 }
 
 export interface ParsedNoteContent {
@@ -45,6 +49,8 @@ export function parseNoteContent(markdown: string): ParsedNoteContent {
       tags: asStringArray(rawMatter.tags),
       publishedOn: asDateString(rawMatter.publishedOn),
       lastModifiedOn: asDateString(rawMatter.lastModifiedOn),
+      series: asOptionalString(rawMatter.series),
+      seriesOrder: asOptionalNumber(rawMatter.seriesOrder),
     },
     mdast,
     summary: extractSummary(mdast),
@@ -85,6 +91,16 @@ function isSummaryNode(node: RootContent): boolean {
 
 function asOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** フロントマターの数値。number か数字文字列を受け、それ以外は undefined。 */
+function asOptionalNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
 }
 
 /**

--- a/app/backend/services/notes-refresh.service.ts
+++ b/app/backend/services/notes-refresh.service.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@js-temporal/polyfill";
+import GithubSlugger from "github-slugger";
 import { toString as mdastToString } from "mdast-util-to-string";
 import { contentTypeForPath } from "./asset-content-type";
 import { resolveAssetUrl } from "./note-asset-url";
@@ -245,6 +246,15 @@ function buildNoteContent(
       parsed.frontmatter.imageUrl === undefined
         ? undefined
         : ImageUrl.create(resolveAssetUrl(slug, parsed.frontmatter.imageUrl));
+    const seriesName = parsed.frontmatter.series;
+    const series =
+      seriesName === undefined
+        ? undefined
+        : {
+            name: seriesName,
+            slug: new GithubSlugger().slug(seriesName),
+            order: parsed.frontmatter.seriesOrder ?? 0,
+          };
     const note = Note.create({
       slug: group.slug,
       title: NoteTitle.create(parsed.frontmatter.title ?? group.base),
@@ -253,6 +263,7 @@ function buildNoteContent(
       tags: parsed.frontmatter.tags.map((tag) => NoteTag.create(tag)),
       publishedOn,
       lastModifiedOn,
+      series,
       sourceHash: group.contentHash,
     });
 

--- a/app/frontend/pages/notes/show.tsx
+++ b/app/frontend/pages/notes/show.tsx
@@ -22,11 +22,21 @@ interface NoteMeta {
   readonly lastModifiedOn: string;
 }
 
+interface SeriesNav {
+  readonly name: string;
+  readonly slug: string;
+  readonly total: number;
+  readonly position: number;
+  readonly prev: NoteMeta | null;
+  readonly next: NoteMeta | null;
+}
+
 interface NoteShowProps extends PageProps {
   readonly note: NoteMeta | null;
   readonly mdast: MdastRoot | null;
   readonly related?: readonly NoteMeta[];
   readonly headings?: readonly TocHeading[];
+  readonly series?: SeriesNav | null;
 }
 
 export default function NoteShow({
@@ -34,6 +44,7 @@ export default function NoteShow({
   mdast,
   related = [],
   headings = [],
+  series = null,
 }: NoteShowProps): React.JSX.Element {
   const { t } = useTranslation();
 
@@ -96,6 +107,42 @@ export default function NoteShow({
             )}
           </header>
           <MdastRenderer node={mdast} />
+          {series !== null && (
+            <nav className="mt-12 rounded-xl border border-base-300 bg-base-200 p-5">
+              <Link
+                href={`/series/${series.slug}`}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                {t("series.label")}: {series.name}
+              </Link>
+              <p className="mt-1 text-xs text-base-content/60">
+                {t("series.position", {
+                  position: series.position,
+                  total: series.total,
+                })}
+              </p>
+              <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-between">
+                {series.prev === null ? (
+                  <span />
+                ) : (
+                  <Link
+                    href={`/notes/${series.prev.slug}`}
+                    className="text-sm text-base-content/80 hover:text-primary"
+                  >
+                    ← {series.prev.title}
+                  </Link>
+                )}
+                {series.next !== null && (
+                  <Link
+                    href={`/notes/${series.next.slug}`}
+                    className="text-sm text-base-content/80 hover:text-primary sm:text-right"
+                  >
+                    {series.next.title} →
+                  </Link>
+                )}
+              </div>
+            </nav>
+          )}
           {related.length > 0 && (
             <section className="mt-16 border-t border-base-300 pt-10">
               <h2 className="mb-6 text-xl font-bold">{t("notes.related")}</h2>

--- a/app/frontend/pages/series/show.tsx
+++ b/app/frontend/pages/series/show.tsx
@@ -1,0 +1,68 @@
+import { Head, Link } from "@inertiajs/react";
+import { useTranslation } from "react-i18next";
+import type { PageProps } from "~/frontend/page-props";
+import { Footer } from "~/frontend/components/layout/footer";
+import { Header } from "~/frontend/components/layout/header";
+import { NoteCard } from "~/frontend/components/note-card/note-card";
+import { AppLayout } from "~/frontend/layouts/app-layout";
+
+interface NoteMeta {
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly imageUrl: string | null;
+  readonly tags: readonly string[];
+  readonly publishedOn: string;
+}
+
+interface SeriesShowProps extends PageProps {
+  readonly name: string | null;
+  readonly notes: readonly NoteMeta[];
+}
+
+export default function SeriesShow({
+  name,
+  notes,
+}: SeriesShowProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  if (name === null) {
+    return (
+      <AppLayout>
+        <Head title={t("series.notFound.title")} />
+        <Header />
+        <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-16 text-center">
+          <h1 className="text-3xl font-bold">{t("series.notFound.heading")}</h1>
+          <Link href="/notes" className="btn btn-primary mt-8">
+            {t("notes.notFound.backToList")}
+          </Link>
+        </main>
+        <Footer />
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <Head title={name} />
+      <Header />
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-10">
+        <p className="text-sm font-medium text-accent-content">
+          {t("series.label")}
+        </p>
+        <h1 className="mt-1 text-3xl font-bold">{name}</h1>
+        <p className="mt-2 text-sm text-base-content/60">
+          {t("series.count", { count: notes.length })}
+        </p>
+        <ol className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {notes.map((note) => (
+            <li key={note.slug}>
+              <NoteCard {...note} />
+            </li>
+          ))}
+        </ol>
+      </main>
+      <Footer />
+    </AppLayout>
+  );
+}

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -40,6 +40,15 @@
     "empty": "No matching notes.",
     "resultCount": "{{count}} results"
   },
+  "series": {
+    "label": "Series",
+    "count": "{{count}} articles",
+    "position": "{{position}} of {{total}}",
+    "notFound": {
+      "title": "Series not found",
+      "heading": "Series not found"
+    }
+  },
   "login": {
     "heading": "Sign in",
     "description": "Enter your email address. We'll send you a magic link to sign in.",

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -40,6 +40,15 @@
     "empty": "一致するノートがない。",
     "resultCount": "{{count}} 件"
   },
+  "series": {
+    "label": "連載",
+    "count": "全 {{count}} 記事",
+    "position": "{{position}} / {{total}}",
+    "notFound": {
+      "title": "連載が見つからない",
+      "heading": "連載が見つからない"
+    }
+  },
   "login": {
     "heading": "ログイン",
     "description": "メールアドレスを入力すると、サインイン用のマジックリンクを送信します。",

--- a/migrations/0004_add_notes_series.sql
+++ b/migrations/0004_add_notes_series.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `notes` ADD `series` text;--> statement-breakpoint
+ALTER TABLE `notes` ADD `series_slug` text;--> statement-breakpoint
+ALTER TABLE `notes` ADD `series_order` integer;

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,222 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eb5cc7f7-f706-43b5-90b5-96cc796e6ee9",
+  "prevId": "b5119c8b-6c9b-4c3b-960c-08c4ac30e240",
+  "tables": {
+    "note_tags": {
+      "name": "note_tags",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_tags_tag_idx": {
+          "name": "note_tags_tag_idx",
+          "columns": ["tag"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_tags_note_id_notes_id_fk": {
+          "name": "note_tags_note_id_notes_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "notes",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_tags_note_id_tag_pk": {
+          "columns": ["note_id", "tag"],
+          "name": "note_tags_note_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series": {
+          "name": "series",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_slug": {
+          "name": "series_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_order": {
+          "name": "series_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_on": {
+          "name": "published_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified_on": {
+          "name": "last_modified_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_slug_unique": {
+          "name": "notes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783308870518,
       "tag": "0003_create_note_tags_table",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1783555185557,
+      "tag": "0004_add_notes_series",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #55。frontmatter series + seriesOrder → 記事の前後ナビ + /series/:slug 索引。notes に series 列追加 (migration 0004)。staging で JOI 3 記事を連載化して動作確認済み (索引・前後ナビ・位置表示)。