### PR TITLE
fix: 記事レイアウト改善 (ToC 無し中央寄せ + アンカーずれ)

### DIFF
--- a/app/frontend/components/mdast/mdast-renderer.css
+++ b/app/frontend/components/mdast/mdast-renderer.css
@@ -201,3 +201,8 @@
   appearance: none;
   width: 100%;
 }
+
+/* ToC / パーマリンクで見出しへ飛んだとき sticky ヘッダーに隠れないよう余白を確保。 */
+.note-prose :is(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: 5rem;
+}

--- a/app/frontend/pages/notes/show.tsx
+++ b/app/frontend/pages/notes/show.tsx
@@ -73,8 +73,8 @@ export default function NoteShow({
         <meta name="description" content={note.summary} />
       </Head>
       <Header />
-      <div className="mx-auto flex w-full max-w-6xl flex-1 gap-10 px-6 py-10">
-        <main className="min-w-0 max-w-3xl flex-1">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 justify-center gap-10 px-6 py-10">
+        <main className="w-full min-w-0 max-w-3xl">
           <header className="mb-8">
             <h1 className="text-4xl font-bold">{note.title}</h1>
             <time
@@ -154,11 +154,13 @@ export default function NoteShow({
             </section>
           )}
         </main>
-        <aside className="hidden w-60 shrink-0 lg:block">
-          <div className="sticky top-24">
-            <TableOfContents title={t("notes.toc")} headings={headings} />
-          </div>
-        </aside>
+        {headings.length >= 2 && (
+          <aside className="hidden w-60 shrink-0 lg:block">
+            <div className="sticky top-24">
+              <TableOfContents title={t("notes.toc")} headings={headings} />
+            </div>
+          </aside>
+        )}
       </div>
       <Footer />
     </AppLayout>


### PR DESCRIPTION
Closes #70。実画面レビューで発見した 2 点を修正。①ToC 無し記事を中央寄せ ②見出しに scroll-margin-top。staging で目視確認済み。