### PR TITLE
feat: タグクラウド + カラーテーマ不適用の修正

### DIFF
--- a/app/frontend/app.css
+++ b/app/frontend/app.css
@@ -7,7 +7,8 @@
  * 主役 (primary)、tan/gold を差し色 (accent)、青を補助 (secondary)、rose をエラー系に。
  * 白シンプル・可読性重視 (装飾色は白地で低コントラストなので働く色は紺で担う)。 */
 @plugin "daisyui/theme" {
-  name: "light";
+  /* 組込みテーマ "light" と名前が衝突すると組込み既定色が勝つため、一意名にする。 */
+  name: "yantene";
   default: true;
   color-scheme: light;
 

--- a/app/frontend/pages/tags/index.tsx
+++ b/app/frontend/pages/tags/index.tsx
@@ -14,28 +14,50 @@ interface TagsIndexProps extends PageProps {
   readonly tags: readonly TagCount[];
 }
 
+/** 記事数 → フォントサイズ(rem)・太さ。頻度をサイズで表すタグクラウド用。 */
+function scaleByCount(
+  count: number,
+  min: number,
+  max: number,
+): { fontSize: string; fontWeight: number } {
+  const ratio = max === min ? 0.5 : (count - min) / (max - min);
+  return {
+    fontSize: `${(1 + ratio * 1.7).toFixed(3)}rem`,
+    fontWeight: 400 + Math.round(ratio * 3) * 100,
+  };
+}
+
 export default function TagsIndex({ tags }: TagsIndexProps): React.JSX.Element {
   const { t } = useTranslation();
+  const counts = tags.map((tag) => tag.count);
+  const min = counts.length > 0 ? Math.min(...counts) : 0;
+  const max = counts.length > 0 ? Math.max(...counts) : 0;
+  // クラウドらしく散らすため名前順に並べる (大小が混ざる)。サイズが頻度を担う。
+  const sorted = tags.toSorted((a, b) => a.tag.localeCompare(b.tag, "ja"));
 
   return (
     <AppLayout>
       <Head title={t("tags.title")} />
       <Header />
-      <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-10">
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-6 py-10">
         <h1 className="text-3xl font-bold">{t("tags.heading")}</h1>
 
         {tags.length === 0 ? (
           <p className="mt-8 text-base-content/60">{t("tags.empty")}</p>
         ) : (
-          <ul className="mt-8 flex flex-wrap gap-3">
-            {tags.map(({ tag, count }) => (
+          <ul className="mt-12 flex flex-wrap items-baseline justify-center gap-x-7 gap-y-5">
+            {sorted.map(({ tag, count }) => (
               <li key={tag}>
                 <Link
                   href={`/notes?tag=${encodeURIComponent(tag)}`}
-                  className="badge badge-lg badge-outline gap-2 py-3 hover:badge-primary"
+                  style={scaleByCount(count, min, max)}
+                  className="leading-none text-primary underline-offset-4 transition-colors hover:decoration-accent hover:underline"
+                  title={t("tags.articleCount", { count })}
                 >
-                  <span>{tag}</span>
-                  <span className="text-xs opacity-60">{count}</span>
+                  {tag}
+                  <sub className="ml-0.5 align-baseline text-[0.55em] font-normal text-base-content/45">
+                    {count}
+                  </sub>
                 </Link>
               </li>
             ))}

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -108,7 +108,7 @@ export const rootView: RootView = async (page, c) => {
   // hydration 対象がずれる・data-page 属性が壊れるため、body をそのまま配置する。
   // テーマは light 固定 (ダークモード不採用)。
   return `<!DOCTYPE html>
-<html lang="${locale}" data-theme="light">
+<html lang="${locale}" data-theme="yantene">
   <head>
     ${headHtml}
   </head>

--- a/app/lib/i18n/locales/en.json
+++ b/app/lib/i18n/locales/en.json
@@ -12,7 +12,8 @@
   "tags": {
     "title": "Tags",
     "heading": "Tags",
-    "empty": "No tags yet."
+    "empty": "No tags yet.",
+    "articleCount": "{{count}} articles"
   },
   "notes": {
     "title": "Notes",

--- a/app/lib/i18n/locales/ja.json
+++ b/app/lib/i18n/locales/ja.json
@@ -12,7 +12,8 @@
   "tags": {
     "title": "タグ",
     "heading": "タグ",
-    "empty": "タグがまだない。"
+    "empty": "タグがまだない。",
+    "articleCount": "{{count}} 記事"
   },
   "notes": {
     "title": "ノート",


### PR DESCRIPTION
Closes #72。①タグページをタグクラウド化（記事数でサイズ）。②**重要**: daisyUI テーマ名が組込み light と衝突し紺パレットが全サイトで無効だった不具合を修正（theme→yantene）。ブラウザで computed `--color-primary: #2b4a76` を確認済み。