### PR TITLE
fix: CSP でブロックされる inline 依存を一掃する

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -199,6 +199,21 @@ Foo.reconstruct(params): Foo<IPersisted>     // DB から復元済み
   または関数を分離する
 - TDD: Red → Green → Refactor
 
+## inline style を使わない (CSP)
+
+CSP が `style-src 'self'` (`'unsafe-inline'` なし) なので、**ブラウザは inline `style`
+属性を丸ごと無視する**。nonce は要素にしか付けられず属性には効かないため、`style={...}`
+で渡した値は本番で必ず消える。しかも例外も警告も出ず、見た目だけが静かに壊れる。
+
+- 見た目の可変軸は**静的な CSS のクラスの段階**として持つ (連続値は使えない)
+- コンポーネント CSS は `app.css` に `@import` で束ねる。dev の Vite は
+  `import "./x.css"` を JS からの `<style>` 注入で届けるが、それも CSP に落とされる
+- 自前で出す inline `<script>` には `c.get("secureHeadersNonce")` の nonce を付ける
+- `app/frontend/**/*.tsx` では ESLint (`react/forbid-dom-props`) が `style` を弾く
+- 見た目の確認は `pnpm dev` か `vite preview` で行う (Storybook には CSP が無い)
+
+判断の経緯は [ADR 0009](../../docs/adr/0009-strict-csp-without-unsafe-inline.md) を参照。
+
 ## URL 命名規則
 
 URL パスセグメントとクエリパラメータは kebab-case で統一する。

--- a/app/frontend/app.css
+++ b/app/frontend/app.css
@@ -1,4 +1,11 @@
 @import "tailwindcss" source(".");
+
+/* コンポーネント CSS はここに束ねる。dev の Vite は component の `import "./x.css"` を
+ * JS からの <style> 注入で届けるが、CSP (style-src 'self') がそれをブロックするため
+ * dev でだけスタイルが丸ごと消える。app.css は <link> で届くのでその影響を受けない。 */
+@import "./components/hero/celestim.css";
+@import "./components/mdast/mdast-renderer.css";
+
 @plugin "daisyui";
 @plugin "@tailwindcss/typography";
 

--- a/app/frontend/components/hero/celestim.css
+++ b/app/frontend/components/hero/celestim.css
@@ -27,9 +27,9 @@
 
 .celestim-sky {
   /*
-   * 既定値はここに置く。CSP (style-src 'self') 下ではブラウザが style 属性を
-   * 丸ごと無視するため、既定の描画を inline style の custom property に
-   * 依存させると空も天体も出なくなる。Celestim の props はこれを上書きする。
+   * 設定値はここに置く。CSP (style-src 'self') 下ではブラウザが style 属性を
+   * 丸ごと無視するため、inline style の custom property で渡すと本番でだけ
+   * 設定が消えて空も天体も出なくなる。可変にしたい軸はクラスで用意する。
    */
   --celestim-one-day: 288s;
   --celestim-sidereal-month: 28;
@@ -85,6 +85,15 @@
 
 .celestim-sky-veiled {
   animation-name: celestim-veiled-sky-cycle;
+}
+
+/* 全周期を短時間で見るための速度違い (主に Storybook 用)。 */
+.celestim-sky-fast {
+  --celestim-one-day: 24s;
+}
+
+.celestim-sky-slow {
+  --celestim-one-day: 600s;
 }
 
 /*

--- a/app/frontend/components/hero/celestim.stories.tsx
+++ b/app/frontend/components/hero/celestim.stories.tsx
@@ -24,20 +24,20 @@ export const Default: Story = {};
 
 export const FastCycle: Story = {
   args: {
-    dayDuration: 24,
+    speed: "fast",
   },
 };
 
 /** 文字を重ねる用途 (ヒーロー) の見え方。夜側ほど白が濃くなる。 */
 export const Veiled: Story = {
   args: {
-    dayDuration: 24,
+    speed: "fast",
     veil: true,
   },
 };
 
 export const SlowCycle: Story = {
   args: {
-    dayDuration: 600,
+    speed: "slow",
   },
 };

--- a/app/frontend/components/hero/celestim.tsx
+++ b/app/frontend/components/hero/celestim.tsx
@@ -1,22 +1,21 @@
-import "./celestim.css";
-
 /*
- * 各既定値は celestim.css の `.celestim-sky` が持つ。ここで既定を埋めて style 属性に
- * 書き出すことはしない — CSP (style-src 'self') 下ではブラウザが style 属性ごと
- * 無視するため、既定の描画が inline style に依存していると何も表示されなくなる。
- * props は「CSP の無い環境 (Storybook 等) での上書き」として扱う。
+ * 設定値はすべて celestim.css の `.celestim-sky` が CSS 変数として持つ。
+ * inline style で渡す手は使えない — CSP (style-src 'self') 下ではブラウザが
+ * style 属性ごと無視するため、本番でだけ設定が消えて空も天体も出なくなる。
+ * 可変にしたい軸はクラスの段階として CSS 側に用意する。
  */
+/** 全周期を短時間で見たいとき (主に Storybook) 用の速度違い。 */
+type CelestimSpeed = "normal" | "fast" | "slow";
+
+function speedClass(speed: CelestimSpeed): string {
+  if (speed === "fast") return " celestim-sky-fast";
+  if (speed === "slow") return " celestim-sky-slow";
+  return "";
+}
+
 type CelestimProps = {
-  /** Duration of one day cycle in seconds (default: 288) */
-  readonly dayDuration?: number;
-  /** Sidereal month length in days (default: 28) */
-  readonly siderealMonth?: number;
-  /** Orbit diameter as CSS value (default: "min(100vw, 1200px)") */
-  readonly orbitDiameter?: string;
-  /** Celestial body size as CSS value (default: "clamp(28px, 5.5vw, 72px)") */
-  readonly bodySize?: string;
-  /** How far below the container bottom to push the orbit center (default: "60%") */
-  readonly horizonDrop?: string;
+  /** Length of one day cycle (default: "normal" = 288s) */
+  readonly speed?: CelestimSpeed;
   /**
    * Brighten the sky so that text drawn on top stays readable at every hour.
    * 空だけを見せる用途では素の色のほうが良いので既定は無効。
@@ -25,31 +24,13 @@ type CelestimProps = {
 };
 
 export function Celestim({
-  dayDuration,
-  siderealMonth,
-  orbitDiameter,
-  bodySize,
-  horizonDrop,
+  speed = "normal",
   veil = false,
 }: CelestimProps = {}): React.JSX.Element {
-  const overrides = {
-    "--celestim-one-day":
-      dayDuration === undefined ? undefined : `${String(dayDuration)}s`,
-    "--celestim-sidereal-month":
-      siderealMonth === undefined ? undefined : String(siderealMonth),
-    "--celestim-orbit-diameter": orbitDiameter,
-    "--celestim-body-size": bodySize,
-    "--celestim-horizon-drop": horizonDrop,
-  };
-  const cssVars = Object.fromEntries(
-    Object.entries(overrides).filter(([, value]) => value !== undefined),
-  ) as React.CSSProperties;
+  const className = `celestim-sky${veil ? " celestim-sky-veiled" : ""}${speedClass(speed)}`;
 
   return (
-    <div
-      className={`celestim-sky${veil ? " celestim-sky-veiled" : ""}`}
-      style={Object.keys(cssVars).length > 0 ? cssVars : undefined}
-    >
+    <div className={className}>
       <div className="celestim-turntable celestim-lunar-turntable">
         <div className="celestim-moon celestim-moon-light celestim-moon-light-left celestim-celestial-body" />
         <div className="celestim-moon celestim-moon-light celestim-moon-light-right celestim-celestial-body" />

--- a/app/frontend/components/layout/footer.tsx
+++ b/app/frontend/components/layout/footer.tsx
@@ -1,7 +1,4 @@
-// フッター帯も Celestim と同じ空のサイクルで塗る。keyframes の定義元なので、
-// ヒーローの無いページでもアニメが効くよう明示的に読み込む。
-import "~/frontend/components/hero/celestim.css";
-
+// フッター帯も Celestim と同じ空のサイクルで塗る (keyframes は app.css 経由で届く)。
 const currentYear = new Date().getFullYear();
 
 export function Footer(): React.JSX.Element {

--- a/app/frontend/components/mdast/mdast-renderer.tsx
+++ b/app/frontend/components/mdast/mdast-renderer.tsx
@@ -7,7 +7,6 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeSanitize from "rehype-sanitize";
 import rehypeSlug from "rehype-slug";
 import { unified } from "unified";
-import "./mdast-renderer.css";
 import type { Element, Root as HastRoot, RootContent } from "hast";
 import type { Root as MdastRoot } from "mdast";
 

--- a/app/frontend/pages/tags/index.tsx
+++ b/app/frontend/pages/tags/index.tsx
@@ -14,17 +14,26 @@ interface TagsIndexProps extends PageProps {
   readonly tags: readonly TagCount[];
 }
 
-/** 記事数 → フォントサイズ(rem)・太さ。頻度をサイズで表すタグクラウド用。 */
-function scaleByCount(
-  count: number,
-  min: number,
-  max: number,
-): { fontSize: string; fontWeight: number } {
+/*
+ * 頻度を表す大小は静的なクラスの段階で持つ。inline style で連続値を渡すと
+ * CSP (style-src 'self') に style 属性ごと落とされ、全部同じ大きさになる。
+ * 文字列リテラルで書くことで Tailwind のスキャンにも乗る。
+ */
+const tagScales = [
+  "text-base font-normal",
+  "text-lg font-normal",
+  "text-xl font-medium",
+  "text-2xl font-semibold",
+  "text-3xl font-semibold",
+  "text-4xl font-bold",
+] as const;
+
+/** 記事数 → タグクラウドの大小クラス。 */
+function scaleByCount(count: number, min: number, max: number): string {
   const ratio = max === min ? 0.5 : (count - min) / (max - min);
-  return {
-    fontSize: `${(1 + ratio * 1.7).toFixed(3)}rem`,
-    fontWeight: 400 + Math.round(ratio * 3) * 100,
-  };
+  const step = Math.round(ratio * (tagScales.length - 1));
+
+  return tagScales.at(step) ?? tagScales[0];
 }
 
 export default function TagsIndex({ tags }: TagsIndexProps): React.JSX.Element {
@@ -50,8 +59,7 @@ export default function TagsIndex({ tags }: TagsIndexProps): React.JSX.Element {
               <li key={tag}>
                 <Link
                   href={`/notes?tag=${encodeURIComponent(tag)}`}
-                  style={scaleByCount(count, min, max)}
-                  className="leading-none text-primary underline-offset-4 transition-colors hover:decoration-accent hover:underline"
+                  className={`${scaleByCount(count, min, max)} leading-none text-primary underline-offset-4 transition-colors hover:decoration-accent hover:underline`}
                   title={t("tags.articleCount", { count })}
                 >
                   {tag}

--- a/app/frontend/root-view.test.tsx
+++ b/app/frontend/root-view.test.tsx
@@ -14,8 +14,13 @@ const { rootView } = await import("./root-view");
 
 function context(
   url = "http://localhost/notes",
+  nonce: string | undefined = "test-nonce",
 ): Parameters<typeof rootView>[1] {
-  return { req: { url } } as unknown as Parameters<typeof rootView>[1];
+  return {
+    req: { url },
+    // secureHeaders が仕込む nonce。dev の react-refresh プリアンブルに載る。
+    get: (key: string) => (key === "secureHeadersNonce" ? nonce : undefined),
+  } as unknown as Parameters<typeof rootView>[1];
 }
 
 describe("rootView", () => {

--- a/app/frontend/root-view.tsx
+++ b/app/frontend/root-view.tsx
@@ -1,10 +1,5 @@
 import { renderToString } from "react-dom/server";
-import {
-  Link,
-  ReactRefresh,
-  Script,
-  ViteClient,
-} from "vite-ssr-components/react";
+import { Link, Script, ViteClient } from "vite-ssr-components/react";
 import type { RootView } from "@hono/inertia";
 import { renderPage } from "~/frontend/entry.server";
 import { renderJsonLd } from "~/frontend/json-ld";
@@ -28,13 +23,47 @@ interface OgValues {
   readonly type: string;
 }
 
+/*
+ * vite-ssr-components の <ReactRefresh /> は nonce を受け取れず、react-refresh の
+ * プリアンブルを nonce 無しの inline <script> で出す。CSP (script-src 'nonce-…' 'self')
+ * がそれをブロックするため __vite_plugin_react_preamble_installed__ が立たず、
+ * client entry が "can't detect preamble" で死んで dev の hydration が起きない。
+ * CSP を緩める代わりに、nonce 付きで自前で出す。
+ */
+// eslint-disable-next-line no-secrets/no-secrets -- vite の内部 URL とスニペットの誤検知。
+const REACT_REFRESH_PREAMBLE = `import RefreshRuntime from '/@react-refresh';
+RefreshRuntime.injectIntoGlobalHook(window);
+window.$RefreshReg$ = () => {};
+window.$RefreshSig$ = () => (type) => type;
+window.__vite_plugin_react_preamble_installed__ = true;`;
+
+function ReactRefresh({
+  nonce,
+}: {
+  readonly nonce: string | undefined;
+}): React.JSX.Element | null {
+  if (import.meta.env.PROD) return null;
+
+  return (
+    <>
+      <script type="module" src="/@react-refresh" />
+      <script
+        type="module"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{ __html: REACT_REFRESH_PREAMBLE }}
+      />
+    </>
+  );
+}
+
 interface HeadProps {
   readonly title: string;
   readonly description: string;
   readonly og: OgValues;
+  readonly nonce: string | undefined;
 }
 
-function Head({ title, description, og }: HeadProps): React.JSX.Element {
+function Head({ title, description, og, nonce }: HeadProps): React.JSX.Element {
   return (
     <>
       <meta charSet="utf-8" />
@@ -62,7 +91,7 @@ function Head({ title, description, og }: HeadProps): React.JSX.Element {
       <meta name="twitter:description" content={og.description} />
       <meta name="twitter:image" content={og.image} />
       <ViteClient />
-      <ReactRefresh />
+      <ReactRefresh nonce={nonce} />
       <Link href="/app/frontend/app.css" rel="stylesheet" />
       <Script src="/app/frontend/entry.client.tsx" />
     </>
@@ -95,10 +124,18 @@ export const rootView: RootView = async (page, c) => {
 
   const jsonLdScript = renderJsonLd(page.props.jsonLd);
 
+  // secureHeaders が NONCE を要求したときだけ値が入る (本番も dev も入る)。
+  const nonce = c.get("secureHeadersNonce");
+
   const { head, body } = await renderPage(page);
   const headHtml =
     renderToString(
-      <Head title={meta.title} description={meta.description} og={og} />,
+      <Head
+        title={meta.title}
+        description={meta.description}
+        og={og}
+        nonce={nonce}
+      />,
     ) +
     head.join("") +
     jsonLdScript;

--- a/docs/adr/0009-strict-csp-without-unsafe-inline.md
+++ b/docs/adr/0009-strict-csp-without-unsafe-inline.md
@@ -1,0 +1,73 @@
+# 0009. CSP を厳格に保ち、見た目は inline ではなく静的な CSS で表現する
+
+- Status: Accepted
+- Date: 2026-07-28
+- Deciders: @yantene
+
+## Context / 背景
+
+`app/backend/index.ts` の `secureHeaders` は `style-src 'self'` /
+`script-src 'nonce-…' 'self'` を出しており、`'unsafe-inline'` を含まない。
+このとき **ブラウザは inline `style` 属性を丸ごと無視する**。nonce は要素
+(`<style>` / `<script>`) にしか付けられず、属性には効かないため、
+`style={...}` で渡した値は本番で必ず消える。
+
+これを知らずに書いたコードが繰り返し壊れた。
+
+- Celestim (トップページの天体アニメ) が CSS 変数を `style` 属性で渡していたため、
+  初回コミットから一度も描画されていなかった ([#78](https://github.com/yantene/yantene.net/issues/78))
+- タグクラウドの文字サイズ強弱が同じ理由で効いていなかった ([#80](https://github.com/yantene/yantene.net/issues/80))
+- dev の react-refresh プリアンブルが nonce 無しの inline `<script>` だったため、
+  `pnpm dev` で hydration が起きなかった (同 #80)
+
+いずれも**単体テストでは検知できず、CSP ヘッダが付いた実環境でしか露見しない**。
+しかも「静かに壊れる」— 例外も警告も出ず、ただ見た目が消える。
+
+## 検討した選択肢
+
+- **案 A: `'unsafe-inline'` を追加する** — 一行で全部直る。
+  - Pros: 実装の自由度が最大。React の `style` prop がそのまま使える。
+  - Cons: XSS 緩和という CSP の主目的を捨てる。ノート本文は外部 (Artifacts) 由来の
+    Markdown をレンダリングするため、inline 実行を許すリスクは実在する。
+- **案 B: 開発環境だけ CSP を緩める** — 本番は厳格のまま。
+  - Pros: DX が戻る。
+  - Cons: dev と本番で挙動が変わる。上記 3 件はいずれも「dev では動くのに本番で消える」
+    型の事故であり、まさにこの差分が原因で長期間気づけなかった。差を広げる方向は逆行。
+- **案 C: CSP は据え置き、inline に依存しない書き方に寄せる** — 可変にしたい軸は
+  クラスの段階として CSS 側に用意し、要素として出す inline `<script>` には nonce を付ける。
+  - Pros: 本番と同じ制約下で開発できる。lint で機械的に守れる。
+  - Cons: 連続値 (任意の rem 値など) が使えず、段階に離散化する必要がある。
+
+## 決定
+
+**案 C を採用する。** CSP に `'unsafe-inline'` を足さない。dev でも緩めない。
+
+- 見た目の可変軸は**静的な CSS のクラス**として持つ
+  (例: タグクラウドの大小は 6 段階のクラス、Celestim の速度は `celestim-sky-fast` 等)。
+- コンポーネント CSS は `app.css` に `@import` で束ねる。dev の Vite は
+  `import "./x.css"` を JS からの `<style>` 注入で届けるが、それも `style-src` に
+  ブロックされるため。`app.css` は `<link>` で届くので影響を受けない。
+- 自前で出す inline `<script>` には `c.get("secureHeadersNonce")` の nonce を付ける。
+- `app/frontend/**/*.tsx` では ESLint (`react/forbid-dom-props`) で `style` を禁止する。
+
+## 帰結 / Consequences
+
+- 良い面: 本番と同じ制約で開発するので、この型の事故が dev で再現する。
+  lint が入ったので新規混入はコミット前に落ちる。
+- 悪い面・トレードオフ:
+  - 連続値が使えない。タグクラウドは 6 段階に離散化した (視覚的には十分だが、
+    件数の差をピクセル単位で反映することはできない)。
+  - コンポーネント CSS の co-location が弱まる。`x.tsx` の隣に `x.css` は置くが、
+    読み込みは `app.css` 経由になり、宣言と読み込みが 1 ファイルに閉じない。
+  - サードパーティのコンポーネントが nonce を受け取れない場合、自前で書き直す必要がある
+    (`vite-ssr-components` の `<ReactRefresh />` は実際にそうした)。
+- 検証方法 / 今後の宣言:
+  - ESLint の `react/forbid-dom-props` が `style` を機械的に弾く。
+  - 見た目に関わる変更は `pnpm dev` (CSP 有効) か `vite preview` で確認する。
+    Storybook には CSP が無いため、Storybook だけの確認では検知できない。
+
+## 参考 / More Information
+
+- [#78](https://github.com/yantene/yantene.net/issues/78) / [#79](https://github.com/yantene/yantene.net/pull/79) — Celestim
+- [#80](https://github.com/yantene/yantene.net/issues/80) — タグクラウド・dev hydration
+- [CSP: style-src — MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@
 | [0006](0006-mdast-over-html-rendering.md)                 | Markdown を HTML ではなく MDAST でフロントエンドに渡す                | Accepted |
 | [0007](0007-artifacts-read-via-binding-token-and-rest.md) | Artifacts のファイル読み取りは binding 発行トークン + REST API で行う | Accepted |
 | [0008](0008-github-as-interim-content-backend.md)         | Artifacts 有効化までは GitHub を暫定コンテンツバックエンドにする      | Accepted |
+| [0009](0009-strict-csp-without-unsafe-inline.md)          | CSP を厳格に保ち、見た目は inline ではなく静的な CSS で表現する       | Accepted |

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -332,6 +332,28 @@ const config = [
     },
   },
 
+  // CSP (style-src 'self') はブラウザに inline style 属性を丸ごと無視させる。
+  // style で渡した値は本番で必ず消えるので、見た目は静的な CSS / クラスで表現する。
+  // 過去に Celestim の CSS 変数とタグクラウドの文字サイズがこれで消えている (#78, #80)。
+  {
+    files: ["app/frontend/**/*.tsx"],
+    ignores: ["app/frontend/**/*.stories.tsx"],
+    rules: {
+      "react/forbid-dom-props": [
+        "error",
+        {
+          forbid: [
+            {
+              propName: "style",
+              message:
+                "CSP (style-src 'self') が inline style 属性を落とすため本番で効かない。CSS / クラスで表現すること。",
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   prettierConfig,
 ] as Linter.Config[];
 


### PR DESCRIPTION
Closes #80

#79 (Celestim) と同じ原因の箇所が残っていたので、まとめて潰した。CSP は緩めていない。

## 1. タグクラウドの文字サイズが効いていなかった

`style={scaleByCount(...)}` で連続値 (rem) を渡していたため、`style-src 'self'` に
style 属性ごと落とされ、全タグが同じ大きさで並んでいた。

6 段階の静的クラス (`text-base font-normal` 〜 `text-4xl font-bold`) に置き換えた。
文字列リテラルで持つので Tailwind のスキャンにも乗る (ビルド成果物で確認済み)。

連続値は使えなくなるので、件数差はピクセル単位ではなく段階で表現される。

## 2. `pnpm dev` で hydration しなかった

`vite-ssr-components` の `<ReactRefresh />` は react-refresh のプリアンブルを
**nonce の無い inline `<script>`** で出す。nonce を受け取る API が無いので
`script-src 'nonce-…' 'self'` にブロックされ、
`window.__vite_plugin_react_preamble_installed__` が立たず client entry が死んでいた。

`c.get("secureHeadersNonce")` の nonce を付けて自前で出すようにした。

## 3. コンポーネント CSS が dev で効いていなかった

dev の Vite は `import "./x.css"` を JS からの `<style>` 注入で届けるが、
それも `style-src` に落とされる (JS 注入の `<style>` が無効化されることを実測で確認)。

`celestim.css` / `mdast-renderer.css` を `app.css` に `@import` で束ね、
`<link>` で届くようにした。co-location は弱まる (宣言と読み込みが別ファイルになる) が、
CSP 下で確実に届く経路はこれしかない。

## 4. 再発防止

同じ踏み外しが 3 回起きているので、`app/frontend/**/*.tsx` で
`react/forbid-dom-props` により `style` を禁止した (stories は除外)。

Celestim も例外にせず、可変軸だった 5 つの props を `speed?: "normal" | "fast" | "slow"`
に畳んで CSS クラスに移し、inline style を完全に無くした。既定値はもともと
`celestim.css` にあるので描画は変わらない。

判断の経緯を [ADR 0009](docs/adr/0009-strict-csp-without-unsafe-inline.md) に、
運用規範を `.claude/rules/architecture.md` に残した。

## 確認方法

`pnpm dev` (CSP 有効) と `vite preview` (本番ビルド) の両方で確認した。

- dev: `__vite_plugin_react_preamble_installed__ === true` / React mount / 空のアニメ 10 個
- タグクラウド: AWS(1) 〜 Ruby(12) で大小が段階的に効くことを目視
- 本番ビルド: `celestim-veiled-sky-cycle` が `<link>` の CSS に含まれ、アニメが動く
- スモーク (`SMOKE_BASE=http://localhost:4176 pnpm run smoke`): HTML ページは全て 200

> `/og/default` だけローカルで 500 になるが、これは R2 にフォント
> (`og/fonts/noto-sans-jp-700-full.ttf`) が無いローカル環境要因で、fail-loud 設計どおりの挙動。
> 本変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S