### PR TITLE
fix: スモークが BASIC 認証の 401 を成功として数えないようにする

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -43,6 +43,7 @@ const paths = [
 ];
 
 let failed = 0;
+let blockedByAuth = 0;
 for (const path of paths) {
   let status = 0;
   try {
@@ -56,13 +57,29 @@ for (const path of paths) {
     failed += 1;
     continue;
   }
-  const isOk = status < 500;
+  // 401/403 はアプリのハンドラまで到達していないということ。500 未満だからと
+  // 成功に数えると、BASIC 認証の壁で止まったまま「全部 ok」になってしまう。
+  const isBlocked = status === 401 || status === 403;
+  const isOk = status < 500 && !isBlocked;
   if (!isOk) failed += 1;
+  if (isBlocked) blockedByAuth += 1;
   console.log(`${isOk ? "ok" : "x "} ${status} ${path}`);
 }
 
+if (blockedByAuth > 0) {
+  console.error(
+    `\nx ${blockedByAuth} path(s) were blocked before reaching the app (401/403).`,
+  );
+  console.error(
+    authHeader.Authorization === undefined
+      ? "  BASIC 認証のある環境には SMOKE_USER / SMOKE_PASS を渡すこと。"
+      : "  SMOKE_USER / SMOKE_PASS が誤っている可能性がある。",
+  );
+}
 if (failed > 0) {
-  console.error(`\nx ${failed} path(s) returned a server error (>= 500)`);
+  console.error(`\nx ${failed} path(s) failed`);
   process.exit(1);
 }
-console.log(`\nok all ${paths.length} paths responded < 500`);
+console.log(
+  `\nok all ${paths.length} paths reached the app and responded < 500`,
+);


### PR DESCRIPTION
Closes #82

## 問題

`scripts/smoke.mjs` の成功条件が `status < 500` だけだった。

staging は BASIC 認証で守られているので、`SMOKE_USER` / `SMOKE_PASS` を渡し忘れると
全パスが 401 を返す。401 は 500 未満なので、スモークは全部成功したように出力して
exit 0 していた。実際にはアプリのハンドラに一度も到達していない。

デプロイ後の最終確認としてスモークを回す運用なのに、認証壁で止まっていることに
気づけないまま「確認した」ことになってしまう。

## 修正

401 / 403 を失敗として扱い、原因 (資格情報の未指定 / 誤り) を出し分けて表示する。

## 確認

```
$ SMOKE_BASE=https://yantene-staging.yantene.workers.dev pnpm run smoke
x  401 /
...
x 11 path(s) were blocked before reaching the app (401/403).
  BASIC 認証のある環境には SMOKE_USER / SMOKE_PASS を渡すこと。

x 11 path(s) failed
→ exit 1
```

認証の無いローカル preview では従来どおり 200/404 を ok と判定することも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Y9ygcYZwG7v8Rw3xQs4S